### PR TITLE
Fix broken links on published website

### DIFF
--- a/website/content/index.md
+++ b/website/content/index.md
@@ -8,7 +8,7 @@ social-github: maveniverse/domtrip
 layout: index
 ---
 
-<link rel="stylesheet" href="/domtrip/css/docusaurus-style.css">
+<link rel="stylesheet" href="{site.url}css/docusaurus-style.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
 
 <!-- Hero Section -->
@@ -16,7 +16,7 @@ layout: index
     <div class="hero-container">
         <h1 class="hero-title">DomTrip</h1>
         <p class="hero-subtitle">Lossless XML Editing for Java</p>
-        <a href="/domtrip/docs/getting-started/quick-start/" class="hero-cta">Get Started - 5min ⏱️</a>
+        <a href="{site.url}docs/getting-started/quick-start/" class="hero-cta">Get Started - 5min ⏱️</a>
     </div>
 </section>
 

--- a/website/templates/layouts/index.html
+++ b/website/templates/layouts/index.html
@@ -97,6 +97,6 @@
     <!-- Note: No Prism.js scripts for index page -->
 
     <!-- Layout functionality -->
-    <script src="/domtrip/js/layout.js"></script>
+    <script src="{site.url}js/layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

The published website at https://maveniverse.github.io/domtrip/docs/ has broken links. For example, the "Installation" link points to `https://maveniverse.github.io/docs/getting-started/installation/` instead of the correct `https://maveniverse.github.io/domtrip/docs/getting-started/installation/`.

The issue occurs because template links are missing the `/domtrip/` repository path prefix when deployed to GitHub Pages.

## Solution

Use ROQ's built-in `site.path-prefix` configuration instead of trying to modify `site.url`. This is the proper, documented way to handle GitHub Pages deployment with ROQ as documented at https://iamroq.com/docs/advanced/#quarkus-roq-frontmatter_site-path-prefix.

### Changes Made

1. **Templates**: Reverted to using standard `{site.url}` variable
   - ROQ automatically handles the path prefix when `site.path-prefix` is set
   - Works correctly in both development (no prefix) and production (with `/domtrip/` prefix)

2. **GitHub Workflow** (requires separate commit due to permissions):
   - Change from `-Dsite.url=$SITE_URL` to `-Dsite.path-prefix=$SITE_PATH` in `.github/workflows/deploy-website.yml`
   - Uses ROQ's native support for path prefixes

## Required Workflow Change

Due to GitHub permissions, the workflow file change needs to be applied separately. In `.github/workflows/deploy-website.yml`, line 49 should be changed from:

```yaml
-Dsite.url=$SITE_URL
```

to:

```yaml
-Dsite.path-prefix=$SITE_PATH
```

## Verification

Tested locally with the build command and confirmed that all generated URLs now correctly include the `/domtrip/` prefix:
- Navigation links: `/domtrip/docs/`, `/domtrip/docs/api/editor/`, etc.
- Asset links: `/domtrip/css/docusaurus-style.css`, `/domtrip/js/layout.js`, etc.
- Content links: `/domtrip/docs/getting-started/quick-start/`

## Benefits

- ✅ Uses ROQ's native functionality (no workarounds)
- ✅ Follows ROQ best practices and documentation
- ✅ Environment-aware (works in both dev and production)
- ✅ Maintainable and clean solution

Fixes the broken links issue where navigation and asset links were missing the repository path prefix on the published GitHub Pages site.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author