### PR TITLE
Update documentation for DomTrip 0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add DomTrip to your Maven project:
 <dependency>
     <groupId>eu.maveniverse.maven.domtrip</groupId>
     <artifactId>domtrip-maven</artifactId>
-    <version>${version.domtrip}</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
@@ -37,14 +37,14 @@ Add DomTrip to your Maven project:
 Editor editor = new Editor(Document.of(xmlString));
 
 // Make targeted changes
-Element version = editor.findElement("version");
+Element version = editor.root().descendant("version").orElseThrow();
 editor.setTextContent(version, "2.0.0");
 
 // Add new elements with automatic formatting
-Element dependencies = editor.findElement("dependencies");
+Element dependencies = editor.root().descendant("dependencies").orElseThrow();
 Element newDep = editor.addElement(dependencies, "dependency");
-editor.addElement(newDep, "groupId").setTextContent("junit");
-editor.addElement(newDep, "artifactId").setTextContent("junit");
+editor.addElement(newDep, "groupId", "junit");
+editor.addElement(newDep, "artifactId", "junit");
 
 // Get result with preserved formatting
 String result = editor.toXml();
@@ -98,35 +98,34 @@ Create XML elements with convenient factory methods:
 
 ```java
 // Simple elements
-Element version = Element.textElement("version", "1.0.0");
-Element properties = Element.emptyElement("properties");
-Element br = Element.selfClosingElement("br");
+Element version = Element.text("version", "1.0.0");
+Element properties = Element.of("properties");
+Element br = Element.selfClosing("br");
 
 // Elements with attributes
 Map<String, String> attrs = Map.of("scope", "test", "optional", "true");
-Element dependency = Element.elementWithAttributes("dependency", attrs);
+Element dependency = Element.withAttributes("dependency", attrs);
 
 // Namespaced elements
-Element soapEnvelope = Element.namespacedElement("soap", "Envelope",
-    "http://schemas.xmlsoap.org/soap/envelope/");
-Element defaultNs = Element.elementInNamespace("http://example.com/ns", "item");
+QName soapEnvelope = QName.of("http://schemas.xmlsoap.org/soap/envelope/", "Envelope", "soap");
+Element nsElement = Element.of(soapEnvelope);
+Element defaultNs = Element.of(QName.of("http://example.com/ns", "item"));
 
 // Documents
-Document doc = Document.withRootElement("project");
-Document minimal = Document.minimal("root");
+Document doc = Document.of().root(Element.of("project"));
+Document withDecl = Document.withXmlDeclaration("1.0", "UTF-8");
 ```
 
-### Builder Patterns
+### Fluent API
 
 Create complex XML structures with fluent APIs:
 
 ```java
-Element dependency = Element.builder("dependency")
-    .withAttribute("scope", "test")
-    .withChild(Element.builder("groupId").withText("junit").build())
-    .withChild(Element.builder("artifactId").withText("junit").build())
-    .withChild(Element.builder("version").withText("4.13.2").build())
-    .build();
+Element dependency = Element.of("dependency")
+    .attribute("scope", "test");
+dependency.addNode(Element.text("groupId", "junit"));
+dependency.addNode(Element.text("artifactId", "junit"));
+dependency.addNode(Element.text("version", "4.13.2"));
 ```
 
 ### Stream-Based Navigation
@@ -136,9 +135,9 @@ Navigate XML documents with Java Streams:
 ```java
 // Find all test dependencies
 root.descendants()
-    .filter(e -> "dependency".equals(e.getName()))
-    .filter(e -> "test".equals(e.getAttribute("scope")))
-    .forEach(dep -> System.out.println(dep.findChild("artifactId").orElse("")));
+    .filter(e -> "dependency".equals(e.name()))
+    .filter(e -> "test".equals(e.attribute("scope")))
+    .forEach(dep -> System.out.println(dep.child("artifactId").map(Element::textContent).orElse("")));
 ```
 
 ### Namespace-Aware Operations
@@ -147,14 +146,13 @@ Work with XML namespaces naturally:
 
 ```java
 // Find elements by namespace URI and local name
-Optional<Element> soapBody = root.findChildByNamespace(
-    "http://schemas.xmlsoap.org/soap/envelope/", "Body");
+QName soapBodyQName = QName.of("http://schemas.xmlsoap.org/soap/envelope/", "Body");
+Optional<Element> soapBody = root.child(soapBodyQName);
 
 // Create namespaced elements
-Element element = Element.builder("item")
-    .withNamespace("ex", "http://example.com/ns")
-    .withDefaultNamespace("http://example.com/default")
-    .build();
+Element element = Element.of("item")
+    .namespaceDeclaration("ex", "http://example.com/ns")
+    .namespaceDeclaration(null, "http://example.com/default");
 ```
 
 ### Configuration Management
@@ -163,12 +161,12 @@ Customize DomTrip behavior for different use cases:
 
 ```java
 // Strict preservation (default)
-DomTripConfig strict = DomTripConfig.strict();
+DomTripConfig strict = DomTripConfig.defaults();
 
 // Pretty printing for clean output
 DomTripConfig pretty = DomTripConfig.prettyPrint()
-    .withIndentation("  ")
-    .withQuoteStyle(QuoteStyle.DOUBLE);
+    .withIndentString("  ")
+    .withDefaultQuoteStyle(QuoteStyle.DOUBLE);
 
 Editor editor = new Editor(Document.of(xml), pretty);
 ```
@@ -319,7 +317,7 @@ DomTrip is licensed under the [Eclipse Public License 2.0](LICENSE).
 ## 🔗 Links
 
 - **📖 [Documentation](https://maveniverse.github.io/domtrip/)**
-- **📦 [Maven Central](https://central.sonatype.com/artifact/eu.maveniverse/domtrip)**
+- **📦 [Maven Central](https://central.sonatype.com/artifact/eu.maveniverse.maven.domtrip/domtrip)**
 - **🐛 [Issues](https://github.com/maveniverse/domtrip/issues)**
 - **💬 [Discussions](https://github.com/maveniverse/domtrip/discussions)**
 

--- a/maven/README.md
+++ b/maven/README.md
@@ -129,7 +129,7 @@ This module depends on:
 <dependency>
     <groupId>eu.maveniverse</groupId>
     <artifactId>domtrip-maven</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 

--- a/website/content/docs/getting-started/installation.md
+++ b/website/content/docs/getting-started/installation.md
@@ -23,7 +23,7 @@ Add DomTrip core to your `pom.xml`:
 <dependency>
     <groupId>eu.maveniverse</groupId>
     <artifactId>domtrip-core</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@ For Maven POM file editing, use the Maven extension which includes the core libr
 <dependency>
     <groupId>eu.maveniverse</groupId>
     <artifactId>domtrip-maven</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
@@ -53,7 +53,7 @@ Add DomTrip core to your `build.gradle`:
 
 ```groovy
 dependencies {
-    implementation 'eu.maveniverse:domtrip-core:0.1-SNAPSHOT'
+    implementation 'eu.maveniverse:domtrip-core:0.2.0'
 }
 ```
 
@@ -63,7 +63,7 @@ For Maven POM editing, use the Maven extension:
 
 ```groovy
 dependencies {
-    implementation 'eu.maveniverse:domtrip-maven:0.1-SNAPSHOT'
+    implementation 'eu.maveniverse:domtrip-maven:0.2.0'
 }
 ```
 
@@ -72,10 +72,10 @@ Or for Kotlin DSL (`build.gradle.kts`):
 ```kotlin
 dependencies {
     // Core library
-    implementation("eu.maveniverse:domtrip-core:0.1-SNAPSHOT")
+    implementation("eu.maveniverse:domtrip-core:0.2.0")
 
     // Or Maven extension (includes core)
-    implementation("eu.maveniverse:domtrip-maven:0.1-SNAPSHOT")
+    implementation("eu.maveniverse:domtrip-maven:0.2.0")
 }
 ```
 
@@ -84,7 +84,7 @@ dependencies {
 Add DomTrip to your `build.sbt`:
 
 ```scala
-libraryDependencies += "eu.maveniverse" % "domtrip-core" % "0.1-SNAPSHOT"
+libraryDependencies += "eu.maveniverse" % "domtrip-core" % "0.2.0"
 ```
 
 ## Verify Installation
@@ -119,7 +119,7 @@ If you see "✅ DomTrip is working!" and "Round-trip successful: true", you're a
 
 ## Snapshot Versions
 
-DomTrip is currently in development. To use snapshot versions, add the snapshot repository:
+To use the latest development snapshot versions, add the snapshot repository:
 
 ### Maven
 

--- a/website/content/docs/maven/index.md
+++ b/website/content/docs/maven/index.md
@@ -124,7 +124,7 @@ Great for analyzing and modifying POMs:
 <dependency>
     <groupId>eu.maveniverse</groupId>
     <artifactId>domtrip-maven</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 

--- a/website/content/docs/maven/installation.md
+++ b/website/content/docs/maven/installation.md
@@ -15,7 +15,7 @@ Add the Maven extension to your project's `pom.xml`:
 <dependency>
     <groupId>eu.maveniverse</groupId>
     <artifactId>domtrip-maven</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ For Gradle projects, add to your `build.gradle`:
 
 ```gradle
 dependencies {
-    implementation 'eu.maveniverse:domtrip-maven:0.1-SNAPSHOT'
+    implementation 'eu.maveniverse:domtrip-maven:0.2.0'
 }
 ```
 
@@ -35,7 +35,7 @@ Or for Gradle Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
 dependencies {
-    implementation("eu.maveniverse:domtrip-maven:0.1-SNAPSHOT")
+    implementation("eu.maveniverse:domtrip-maven:0.2.0")
 }
 ```
 
@@ -130,7 +130,7 @@ If you have version conflicts with transitive dependencies:
 <dependency>
     <groupId>eu.maveniverse</groupId>
     <artifactId>domtrip-maven</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
     <exclusions>
         <exclusion>
             <groupId>*</groupId>
@@ -142,7 +142,7 @@ If you have version conflicts with transitive dependencies:
 <dependency>
     <groupId>eu.maveniverse</groupId>
     <artifactId>domtrip-core</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## 📋 Summary

This PR updates all documentation and website content for the DomTrip 0.2.0 release, including version updates and critical API fixes in the README.

## 🔄 Changes Made

### Version Updates
- Updated all Maven/Gradle dependency examples from `0.1-SNAPSHOT` to `0.2.0`
- Updated installation instructions across all documentation files
- Fixed Maven Central artifact URL in README
- Updated snapshot repository descriptions

### Critical API Fixes in README.md
Fixed numerous outdated API references that were using non-existent methods:

#### Element Navigation
- ❌ `editor.findElement("version")` → ✅ `editor.root().descendant("version").orElseThrow()`
- ❌ `editor.findElement("dependencies")` → ✅ `editor.root().descendant("dependencies").orElseThrow()`

#### Factory Methods
- ❌ `Element.textElement("version", "1.0.0")` → ✅ `Element.text("version", "1.0.0")`
- ❌ `Element.emptyElement("properties")` → ✅ `Element.of("properties")`
- ❌ `Element.selfClosingElement("br")` → ✅ `Element.selfClosing("br")`
- ❌ `Element.elementWithAttributes(...)` → ✅ `Element.withAttributes(...)`

#### Stream Navigation
- ❌ `e.getName()` → ✅ `e.name()`
- ❌ `e.getAttribute("scope")` → ✅ `e.attribute("scope")`
- ❌ `dep.findChild("artifactId")` → ✅ `dep.child("artifactId").map(Element::textContent)`

#### Namespace Operations
- ❌ `root.findChildByNamespace(...)` → ✅ `root.child(QName.of(...))`
- Updated namespace element creation to use correct API

#### Configuration API
- ❌ `withIndentation("  ")` → ✅ `withIndentString("  ")`
- ❌ `withQuoteStyle(QuoteStyle.DOUBLE)` → ✅ `withDefaultQuoteStyle(QuoteStyle.DOUBLE)`

#### Builder Pattern → Fluent API
- Completely rewrote the "Builder Patterns" section as "Fluent API"
- Removed references to non-existent `Element.builder()` methods
- Updated to use correct fluent API: `Element.of("dependency").attribute(...)`

## 📁 Files Updated

- `README.md` - Fixed API examples and updated version references
- `website/content/docs/getting-started/installation.md` - Updated all version numbers
- `website/content/docs/maven/index.md` - Updated Maven dependency versions
- `website/content/docs/maven/installation.md` - Updated all installation examples
- `maven/README.md` - Updated Maven coordinates

## ✅ Testing

- [x] Website builds successfully with updated examples
- [x] All version references consistently use 0.2.0
- [x] Maven Central links point to correct artifact coordinates
- [x] All API examples use correct DomTrip 0.2.0 methods

## 🎯 Impact

- **Users**: Can now copy-paste working code examples from documentation
- **Installation**: Clear instructions for stable 0.2.0 release
- **API Accuracy**: All examples reflect the actual DomTrip API
- **Consistency**: Version numbers consistent across all documentation

**This fixes critical issues where users would encounter compilation errors when following README examples due to outdated API references.**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author