### PR TITLE
Simplify serialization modes and add raw formatting support

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/DomTripConfig.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DomTripConfig.java
@@ -110,6 +110,21 @@ public class DomTripConfig {
         return config;
     }
 
+    /**
+     * Creates a raw configuration for completely unformatted output.
+     *
+     * <p>Raw mode produces XML with no line breaks or indentation whatsoever,
+     * resulting in a single continuous line of XML. This is useful for
+     * minimizing file size or when formatting is not desired.</p>
+     */
+    public static DomTripConfig raw() {
+        DomTripConfig config = new DomTripConfig();
+        config.prettyPrint = true;
+        config.indentString = "";
+        config.lineEnding = "";
+        return config;
+    }
+
     // Fluent setters
     public DomTripConfig withWhitespacePreservation(boolean preserve) {
         this.preserveWhitespace = preserve;

--- a/core/src/test/java/eu/maveniverse/domtrip/SerializationModesDemo.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/SerializationModesDemo.java
@@ -1,0 +1,134 @@
+package eu.maveniverse.domtrip;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Demonstration of the different serialization modes available in DomTrip.
+ * This class shows practical examples of how to use preserve formatting,
+ * pretty print, and raw modes.
+ */
+public class SerializationModesDemo {
+
+    @Test
+    void demonstrateSerializationModes() {
+        // Create a sample document
+        String originalXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!-- Document comment -->\n"
+                + "<root xmlns=\"http://example.com\">\n"
+                + "  <element attr=\"value\">text content</element>\n"
+                + "  <nested>\n"
+                + "    <child>nested content</child>\n"
+                + "  </nested>\n"
+                + "  <!-- inline comment -->\n"
+                + "  <empty/>\n"
+                + "</root>";
+
+        Document document = Document.of(originalXml);
+
+        System.out.println("=== ORIGINAL XML ===");
+        System.out.println(originalXml);
+        System.out.println();
+
+        // 1. Preserve Formatting Mode (Default)
+        System.out.println("=== PRESERVE FORMATTING MODE (Default) ===");
+        Serializer preserveSerializer = new Serializer();
+        String preserveResult = preserveSerializer.serialize(document);
+        System.out.println(preserveResult);
+        System.out.println("Same as original: " + originalXml.equals(preserveResult));
+        System.out.println();
+
+        // 2. Pretty Print Mode
+        System.out.println("=== PRETTY PRINT MODE ===");
+        Serializer prettySerializer = new Serializer();
+        prettySerializer.setPrettyPrint(true);
+        prettySerializer.setIndentString("  "); // 2 spaces
+        prettySerializer.setLineEnding("\n");
+        String prettyResult = prettySerializer.serialize(document);
+        System.out.println(prettyResult);
+        System.out.println();
+
+        // 3. Raw Mode (No Formatting)
+        System.out.println("=== RAW MODE (No Formatting) ===");
+        Serializer rawSerializer = new Serializer(DomTripConfig.raw());
+        String rawResult = rawSerializer.serialize(document);
+        System.out.println(rawResult);
+        System.out.println("Contains line breaks: " + rawResult.contains("\n"));
+        System.out.println("Length: " + rawResult.length() + " characters");
+        System.out.println();
+
+        // 4. Custom Indentation
+        System.out.println("=== CUSTOM INDENTATION (Tabs) ===");
+        Serializer tabSerializer = new Serializer();
+        tabSerializer.setPrettyPrint(true);
+        tabSerializer.setIndentString("\t");
+        String tabResult = tabSerializer.serialize(document);
+        System.out.println(tabResult.replace("\t", "[TAB]")); // Show tabs visually
+        System.out.println();
+
+        // 5. Custom Line Endings
+        System.out.println("=== CUSTOM LINE ENDINGS ===");
+        Serializer customSerializer = new Serializer();
+        customSerializer.setPrettyPrint(true);
+        customSerializer.setIndentString("--");
+        customSerializer.setLineEnding(" | ");
+        String customResult = customSerializer.serialize(document);
+        System.out.println(customResult);
+        System.out.println();
+
+        // 6. Modified Document Behavior
+        System.out.println("=== MODIFIED DOCUMENT BEHAVIOR ===");
+        Editor editor = new Editor(document);
+        Element root = editor.root();
+        editor.addElement(root, "newElement", "new content");
+
+        System.out.println("Preserve mode with modified document:");
+        String modifiedPreserve = preserveSerializer.serialize(document);
+        System.out.println(modifiedPreserve);
+        System.out.println();
+
+        System.out.println("Pretty print mode with modified document:");
+        String modifiedPretty = prettySerializer.serialize(document);
+        System.out.println(modifiedPretty);
+        System.out.println();
+
+        System.out.println("Raw mode with modified document:");
+        String modifiedRaw = rawSerializer.serialize(document);
+        System.out.println(modifiedRaw);
+        System.out.println("Contains line breaks: " + modifiedRaw.contains("\n"));
+    }
+
+    @Test
+    void demonstrateRawModeUseCases() {
+        System.out.println("=== RAW MODE USE CASES ===");
+
+        // Use case 1: Minimizing file size
+        String xml = "<config><setting name=\"debug\" value=\"true\"/><setting name=\"port\" value=\"8080\"/></config>";
+        Document doc = Document.of(xml);
+
+        Serializer rawSerializer = new Serializer(DomTripConfig.raw());
+        String rawResult = rawSerializer.serialize(doc);
+
+        System.out.println("Original: " + xml);
+        System.out.println("Raw mode: " + rawResult);
+        System.out.println("Same content: " + xml.equals(rawResult));
+        System.out.println();
+
+        // Use case 2: Single-line output for logging
+        Document logDoc = Document.withRootElement("log");
+        Element entry = new Element("entry");
+        entry.attribute("timestamp", "2024-01-01T12:00:00Z");
+        entry.attribute("level", "INFO");
+        entry.textContent("Application started");
+        logDoc.root().addNode(entry);
+
+        String logOutput = rawSerializer.serialize(logDoc);
+        System.out.println("Log entry (single line): " + logOutput);
+        System.out.println();
+
+        // Use case 3: Comparing with pretty print
+        Serializer prettySerializer = new Serializer(DomTripConfig.prettyPrint());
+        String prettyOutput = prettySerializer.serialize(logDoc);
+        System.out.println("Same content, pretty printed:");
+        System.out.println(prettyOutput);
+    }
+}

--- a/core/src/test/java/eu/maveniverse/domtrip/SerializationModesTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/SerializationModesTest.java
@@ -1,0 +1,389 @@
+package eu.maveniverse.domtrip;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for different serialization modes: preserve formatting, pretty print, and raw mode.
+ */
+public class SerializationModesTest {
+
+    private Document document;
+    private String originalXml;
+
+    @BeforeEach
+    void setUp() {
+        originalXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!-- Document comment -->\n"
+                + "<root xmlns=\"http://example.com\">\n"
+                + "  <element attr=\"value\">text content</element>\n"
+                + "  <nested>\n"
+                + "    <child>nested content</child>\n"
+                + "  </nested>\n"
+                + "  <!-- inline comment -->\n"
+                + "  <empty/>\n"
+                + "</root>";
+        document = Document.of(originalXml);
+    }
+
+    @Test
+    void testPreserveFormattingMode() {
+        // Default serializer should preserve formatting when prettyPrint = false
+        Serializer serializer = new Serializer();
+        assertFalse(serializer.isPrettyPrint());
+
+        String result = serializer.serialize(document);
+
+        // Should preserve original formatting exactly
+        assertEquals(originalXml, result);
+    }
+
+    @Test
+    void testPrettyPrintMode() {
+        // Pretty print mode should apply consistent formatting
+        Serializer serializer = new Serializer();
+        serializer.setPrettyPrint(true);
+        serializer.setIndentString("  "); // 2 spaces
+
+        String result = serializer.serialize(document);
+
+        // Should have consistent indentation
+        assertTrue(result.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assertTrue(result.contains("<root xmlns=\"http://example.com\">"));
+
+        // Check that elements are properly indented
+        String[] lines = result.split("\n");
+        boolean foundElementLine = false;
+        boolean foundNestedLine = false;
+        boolean foundChildLine = false;
+
+        for (String line : lines) {
+            if (line.contains("<element attr=\"value\">")) {
+                assertTrue(line.startsWith("  "), "element should be indented with 2 spaces");
+                foundElementLine = true;
+            }
+            if (line.contains("<nested>")) {
+                assertTrue(line.startsWith("  "), "nested should be indented with 2 spaces");
+                foundNestedLine = true;
+            }
+            if (line.contains("<child>")) {
+                assertTrue(line.startsWith("    "), "child should be indented with 4 spaces");
+                foundChildLine = true;
+            }
+        }
+
+        assertTrue(foundElementLine, "Should find element line");
+        assertTrue(foundNestedLine, "Should find nested line");
+        assertTrue(foundChildLine, "Should find child line");
+    }
+
+    @Test
+    void testRawMode() {
+        // Create a document without whitespace content for raw mode testing
+        String compactXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<!-- Document comment -->"
+                + "<root xmlns=\"http://example.com\">"
+                + "<element attr=\"value\">text content</element>"
+                + "<nested><child>nested content</child></nested>"
+                + "<!-- inline comment -->"
+                + "<empty/>"
+                + "</root>";
+        Document compactDoc = Document.of(compactXml);
+
+        // Raw mode: no line endings, no indentation
+        Serializer serializer = new Serializer();
+        serializer.setPrettyPrint(true);
+        serializer.setIndentString(""); // No indentation
+        serializer.setLineEnding(""); // No line endings
+
+        String result = serializer.serialize(compactDoc);
+
+        // Should have no line breaks or indentation added by serializer
+        assertFalse(result.contains("\n"), "Raw mode should not contain line breaks");
+
+        // Should still contain all the content
+        assertTrue(result.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assertTrue(result.contains("<root xmlns=\"http://example.com\">"));
+        assertTrue(result.contains("<element attr=\"value\">text content</element>"));
+        assertTrue(result.contains("<nested><child>nested content</child></nested>"));
+        assertTrue(result.contains("<!-- Document comment -->"));
+        assertTrue(result.contains("<!-- inline comment -->"));
+        assertTrue(result.contains("<empty/>"));
+        assertTrue(result.contains("</root>"));
+
+        // The result should be exactly the same as input since no formatting is applied
+        assertEquals(compactXml, result);
+    }
+
+    @Test
+    void testRawModeWithConfig() {
+        // Create a document without whitespace content for raw mode testing
+        String compactXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<root xmlns=\"http://example.com\">"
+                + "<element attr=\"value\">text content</element>"
+                + "</root>";
+        Document compactDoc = Document.of(compactXml);
+
+        // Test raw mode using DomTripConfig
+        DomTripConfig rawConfig =
+                DomTripConfig.prettyPrint().withIndentString("").withLineEnding("");
+
+        Serializer serializer = new Serializer(rawConfig);
+        String result = serializer.serialize(compactDoc);
+
+        // Should have no line breaks or indentation
+        assertFalse(result.contains("\n"), "Raw mode should not contain line breaks");
+
+        // Should still contain all the content
+        assertTrue(result.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assertTrue(result.contains("<root xmlns=\"http://example.com\">"));
+        assertTrue(result.contains("<element attr=\"value\">text content</element>"));
+
+        // The result should be exactly the same as input since no formatting is applied
+        assertEquals(compactXml, result);
+    }
+
+    @Test
+    void testModifiedDocumentBehavior() {
+        // When document is modified, formatting behavior should change
+        Editor editor = new Editor(document);
+        Element root = editor.root();
+        editor.addElement(root, "newElement", "new content");
+
+        // Preserve formatting mode (prettyPrint = false)
+        Serializer preserveSerializer = new Serializer();
+        assertFalse(preserveSerializer.isPrettyPrint());
+        String preserveResult = preserveSerializer.serialize(document);
+
+        // Should still use Element.toXml() for modified elements
+        assertTrue(preserveResult.contains("<newElement>new content</newElement>"));
+
+        // Pretty print mode
+        Serializer prettySerializer = new Serializer();
+        prettySerializer.setPrettyPrint(true);
+        String prettyResult = prettySerializer.serialize(document);
+
+        // Should apply pretty printing formatting
+        assertTrue(prettyResult.contains("\n"));
+        assertTrue(prettyResult.contains("  <newElement>new content</newElement>"));
+    }
+
+    @Test
+    void testDifferentIndentationStyles() {
+        Serializer serializer = new Serializer();
+        serializer.setPrettyPrint(true);
+
+        // Test with tabs
+        serializer.setIndentString("\t");
+        String tabResult = serializer.serialize(document);
+        assertTrue(tabResult.contains("\t<element"));
+
+        // Test with 4 spaces
+        serializer.setIndentString("    ");
+        String fourSpaceResult = serializer.serialize(document);
+        assertTrue(fourSpaceResult.contains("    <element"));
+
+        // Test with custom indentation
+        serializer.setIndentString("--");
+        String customResult = serializer.serialize(document);
+        assertTrue(customResult.contains("--<element"));
+    }
+
+    @Test
+    void testDifferentLineEndings() {
+        Serializer serializer = new Serializer();
+        serializer.setPrettyPrint(true);
+
+        // Test with Windows line endings
+        serializer.setLineEnding("\r\n");
+        String windowsResult = serializer.serialize(document);
+        assertTrue(windowsResult.contains("\r\n"));
+
+        // Test with Unix line endings
+        serializer.setLineEnding("\n");
+        String unixResult = serializer.serialize(document);
+        assertTrue(unixResult.contains("\n"));
+        assertFalse(unixResult.contains("\r\n"));
+
+        // Test with custom line ending
+        serializer.setLineEnding(" | ");
+        String customResult = serializer.serialize(document);
+        assertTrue(customResult.contains(" | "));
+    }
+
+    @Test
+    void testSingleElementRawMode() {
+        Element element = new Element("test");
+        element.attribute("attr", "value");
+        element.textContent("content");
+
+        Serializer serializer = new Serializer();
+        serializer.setPrettyPrint(true);
+        serializer.setIndentString("");
+        serializer.setLineEnding("");
+
+        String result = serializer.serialize(element);
+
+        assertEquals("<test attr=\"value\">content</test>", result);
+        assertFalse(result.contains("\n"));
+        // Should not contain indentation spaces (but attribute spaces are OK)
+        assertFalse(result.contains("  "), "Should not contain indentation spaces");
+    }
+
+    @Test
+    void testEmptyIndentAndLineEndingPreservesContent() {
+        // Ensure that empty indent and line ending don't affect content
+        String xmlWithSpaces = "<root><element>  content with spaces  </element></root>";
+        Document doc = Document.of(xmlWithSpaces);
+
+        Serializer serializer = new Serializer();
+        serializer.setPrettyPrint(true);
+        serializer.setIndentString("");
+        serializer.setLineEnding("");
+
+        String result = serializer.serialize(doc);
+
+        // Content spaces should be preserved
+        assertTrue(result.contains("  content with spaces  "));
+        // But no formatting spaces should be added
+        assertEquals("<root><element>  content with spaces  </element></root>", result);
+    }
+
+    @Test
+    void testRawConfigMethod() {
+        // Test the convenience raw() method in DomTripConfig
+        String compactXml = "<?xml version=\"1.0\"?><root><child>content</child></root>";
+        Document doc = Document.of(compactXml);
+
+        Serializer serializer = new Serializer(DomTripConfig.raw());
+        String result = serializer.serialize(doc);
+
+        // Should produce completely unformatted output
+        assertFalse(result.contains("\n"));
+        assertEquals(compactXml, result);
+    }
+
+    @Test
+    void testRawModeVsPrettyPrintComparison() {
+        // Create a document and compare different serialization modes
+        String xml = "<root><child attr=\"value\">content</child><another>text</another></root>";
+        Document doc = Document.of(xml);
+
+        // Raw mode
+        Serializer rawSerializer = new Serializer(DomTripConfig.raw());
+        String rawResult = rawSerializer.serialize(doc);
+
+        // Pretty print mode
+        Serializer prettySerializer = new Serializer(DomTripConfig.prettyPrint());
+        String prettyResult = prettySerializer.serialize(doc);
+
+        // Preserve formatting mode (default)
+        Serializer preserveSerializer = new Serializer();
+        String preserveResult = preserveSerializer.serialize(doc);
+
+        // Raw should have no line breaks
+        assertFalse(rawResult.contains("\n"));
+        assertEquals(xml, rawResult);
+
+        // Pretty print should have line breaks and indentation
+        assertTrue(prettyResult.contains("\n"));
+        assertTrue(prettyResult.contains("  <child"));
+
+        // Preserve should maintain original formatting (which has no line breaks in this case)
+        assertEquals(xml, preserveResult);
+    }
+
+    @Test
+    void testRawFormattingDetectionAndPreservation() {
+        // Test the key question: when parsing raw XML and adding nodes,
+        // does the system detect and preserve the raw formatting?
+        String rawXml = "<root><existing>content</existing></root>";
+        Document doc = Document.of(rawXml);
+        Editor editor = new Editor(doc);
+
+        // Add a new element
+        Element root = editor.root();
+        editor.addElement(root, "newElement", "new content");
+
+        String result = editor.toXml();
+
+        System.out.println("Original raw XML: " + rawXml);
+        System.out.println("After adding element: " + result);
+        System.out.println("Contains line breaks: " + result.contains("\n"));
+
+        // Now the system should detect raw formatting and preserve it
+        assertFalse(result.contains("\n"), "Should preserve raw formatting when original has no line breaks");
+        assertTrue(result.contains("<newElement>new content</newElement>"), "Should contain the new element");
+
+        // The result should be in raw format
+        String expectedPattern = "<root><existing>content</existing><newElement>new content</newElement></root>";
+        assertEquals(expectedPattern, result);
+    }
+
+    @Test
+    void testEmptyDocumentUsesConfigDefault() {
+        // Test that empty documents use config default, not raw formatting
+        Document emptyDoc = new Document();
+        Editor editor = new Editor(
+                emptyDoc, DomTripConfig.prettyPrint().withLineEnding("\n").withIndentString("  "));
+
+        // Create root element and add content
+        editor.createDocument("root");
+        Element root = editor.root();
+        editor.addElement(root, "child", "content");
+
+        String result = editor.toXml();
+
+        System.out.println("Empty document result: " + result);
+
+        // Should use config defaults (pretty print with line endings), not raw formatting
+        assertTrue(result.contains("\n"), "Empty document should use config default line endings");
+        assertTrue(result.contains("  <child"), "Should have proper indentation");
+    }
+
+    @Test
+    void testFormattingDetectionScenarios() {
+        // Test various scenarios to ensure correct formatting detection
+
+        // Scenario 1: Raw XML (no formatting)
+        String rawXml = "<root><child>content</child></root>";
+        Document rawDoc = Document.of(rawXml);
+        Editor rawEditor = new Editor(rawDoc);
+        rawEditor.addElement(rawEditor.root(), "new", "element");
+        String rawResult = rawEditor.toXml();
+        assertFalse(rawResult.contains("\n"), "Raw XML should preserve raw formatting");
+
+        // Scenario 2: Pretty printed XML
+        String prettyXml = "<root>\n  <child>content</child>\n</root>";
+        Document prettyDoc = Document.of(prettyXml);
+        Editor prettyEditor = new Editor(prettyDoc);
+        prettyEditor.addElement(prettyEditor.root(), "new", "element");
+        String prettyResult = prettyEditor.toXml();
+        assertTrue(prettyResult.contains("\n"), "Pretty XML should preserve pretty formatting");
+        assertTrue(prettyResult.contains("  <new>element</new>"), "Should maintain indentation");
+
+        // Scenario 3: Empty document with default config
+        Document emptyDoc = new Document();
+        Editor emptyEditor = new Editor(emptyDoc); // Uses default config
+        emptyEditor.createDocument("root");
+        emptyEditor.addElement(emptyEditor.root(), "child", "content");
+        String emptyResult = emptyEditor.toXml();
+        // Default config has prettyPrint = false, so it should preserve formatting
+        // But since there's no existing formatting, it uses minimal formatting
+
+        // Scenario 4: Empty document with pretty print config
+        Document emptyPrettyDoc = new Document();
+        Editor emptyPrettyEditor = new Editor(emptyPrettyDoc, DomTripConfig.prettyPrint());
+        emptyPrettyEditor.createDocument("root");
+        emptyPrettyEditor.addElement(emptyPrettyEditor.root(), "child", "content");
+        String emptyPrettyResult = emptyPrettyEditor.toXml();
+        assertTrue(emptyPrettyResult.contains("\n"), "Empty doc with pretty config should use pretty formatting");
+
+        System.out.println("Raw result: " + rawResult);
+        System.out.println("Pretty result: " + prettyResult);
+        System.out.println("Empty default result: " + emptyResult);
+        System.out.println("Empty pretty result: " + emptyPrettyResult);
+    }
+}

--- a/website/content/docs/api/configuration.md
+++ b/website/content/docs/api/configuration.md
@@ -51,6 +51,21 @@ DomTripConfig minimal = DomTripConfig.minimal();
 // - Compact output
 ```
 
+### Raw Configuration
+
+Completely unformatted output (single line, no indentation):
+
+```java
+DomTripConfig raw = DomTripConfig.raw();
+// - No line breaks
+// - No indentation
+// - Single continuous line
+// - Minimal file size
+// - Useful for APIs or storage optimization
+
+// Example output: <root><child>content</child></root>
+```
+
 ## Whitespace Configuration
 
 Control how whitespace is handled:
@@ -156,6 +171,10 @@ DomTripConfig production = DomTripConfig.defaults()
 // API response configuration - minimal output
 DomTripConfig api = DomTripConfig.minimal()
     .withXmlDeclaration(false);
+
+// Raw configuration - completely unformatted
+DomTripConfig raw = DomTripConfig.raw();
+// Perfect for storage optimization or when formatting is not needed
 ```
 
 ## Environment-Specific Configurations

--- a/website/content/docs/features/formatting-preservation.md
+++ b/website/content/docs/features/formatting-preservation.md
@@ -89,26 +89,95 @@ editor.addElement(newDep, "artifactId").setTextContent("mockito-core");
 // Result maintains consistent indentation
 ```
 
+## Automatic Formatting Detection
+
+DomTrip automatically detects the formatting style of existing XML documents and preserves it when adding new content:
+
+```java
+// Raw XML (no formatting) - automatically detected
+String rawXml = "<root><child>content</child></root>";
+Editor editor = new Editor(rawXml);
+editor.addElement(editor.root(), "new", "element");
+// Result: <root><child>content</child><new>element</new></root>
+
+// Pretty XML - formatting preserved
+String prettyXml = """
+    <root>
+        <child>content</child>
+    </root>
+    """;
+Editor prettyEditor = new Editor(prettyXml);
+prettyEditor.addElement(prettyEditor.root(), "new", "element");
+// Result maintains indentation and line breaks
+
+// Custom spacing - patterns preserved
+String customXml = "<root  attr1=\"value1\"   attr2=\"value2\"/>";
+Editor customEditor = new Editor(customXml);
+customEditor.setAttribute(customEditor.root(), "attr3", "value3");
+// Result maintains the custom spacing pattern
+```
+
+## Serialization Modes
+
+DomTrip provides flexible serialization modes to control output formatting:
+
+### Preserve Formatting Mode (Default)
+Maintains original formatting for unmodified content and automatically detects formatting patterns:
+
+```java
+Serializer serializer = new Serializer(); // prettyPrint = false (default)
+String result = serializer.serialize(document);
+// Preserves original formatting exactly
+```
+
+### Pretty Print Mode
+Applies consistent formatting with configurable indentation and line endings:
+
+```java
+Serializer prettySerializer = new Serializer();
+prettySerializer.setPrettyPrint(true);
+prettySerializer.setIndentString("    "); // 4 spaces
+prettySerializer.setLineEnding("\n");
+String prettyResult = prettySerializer.serialize(document);
+```
+
+### Raw Mode
+Produces completely unformatted output with no line breaks or indentation:
+
+```java
+// Using convenience method
+Serializer rawSerializer = new Serializer(DomTripConfig.raw());
+String rawResult = rawSerializer.serialize(document);
+// Result: <root><child>content</child></root>
+
+// Manual configuration
+Serializer manualRaw = new Serializer();
+manualRaw.setPrettyPrint(true);
+manualRaw.setIndentString(""); // No indentation
+manualRaw.setLineEnding("");   // No line endings
+```
+
 ## Configuration Options
 
 You can control formatting behavior through `DomTripConfig`:
 
 ```java
-// Strict preservation (default)
-DomTripConfig strict = DomTripConfig.strict()
-    .withPreserveWhitespace(true)
-    .withPreserveComments(true);
+// Default preservation mode
+DomTripConfig preserve = DomTripConfig.defaults();
 
 // Pretty printing for new content
 DomTripConfig pretty = DomTripConfig.prettyPrint()
-    .withIndentation("    ")  // 4 spaces
-    .withNewlineAfterElements(true);
+    .withIndentString("    ")  // 4 spaces
+    .withLineEnding("\n");
+
+// Raw mode (no formatting)
+DomTripConfig raw = DomTripConfig.raw();
 
 // Custom configuration
-DomTripConfig custom = DomTripConfig.defaults()
-    .withIndentation("  ")    // 2 spaces
-    .withPreserveWhitespace(true)
-    .withQuoteStyle(QuoteStyle.DOUBLE);
+DomTripConfig custom = DomTripConfig.prettyPrint()
+    .withIndentString("\t")    // Tabs
+    .withLineEnding("\r\n")    // Windows line endings
+    .withPreserveComments(true);
 ```
 
 ## Best Practices


### PR DESCRIPTION
## Summary

This PR simplifies the confusing serialization modes and adds support for raw formatting (completely unformatted output). The original implementation had three redundant modes that were functionally identical.

## Changes Made

### 🔧 **Simplified Serialization Modes**
- **Removed** redundant `preserveFormatting` field and related methods
- **Simplified** to two clear modes:
  - `prettyPrint = false` (default): Preserves original formatting
  - `prettyPrint = true`: Applies consistent formatting

### ✨ **New Raw Mode Support**
- **Raw mode**: `lineEnding = ""` + `indentString = ""` produces completely unformatted output
- **Convenience method**: `DomTripConfig.raw()` for easy raw mode configuration
- **Use cases**: API responses, storage optimization, minimal file size

### 🤖 **Automatic Formatting Detection**
- **Smart detection**: Automatically detects formatting patterns in existing XML
- **Raw formatting**: XML with no line breaks/indentation is detected and preserved
- **Pretty formatting**: XML with consistent indentation is detected and preserved
- **Custom formatting**: XML with custom spacing patterns is detected and preserved
- **Empty documents**: Use configuration defaults (not raw formatting)

### 📚 **Documentation Updates**
- **JavaDoc**: Updated Serializer and DomTripConfig documentation
- **Website**: Updated formatting preservation and configuration pages
- **Examples**: Added comprehensive usage examples

### 🧪 **Comprehensive Testing**
- **New test suite**: `SerializationModesTest` with 10+ test scenarios
- **Demo class**: `SerializationModesDemo` showing practical examples
- **Edge cases**: Empty documents, modified vs unmodified content, various formatting styles

## Breaking Changes

⚠️ **Removed API methods:**
- `Serializer.isPreserveFormatting()`
- `Serializer.setPreserveFormatting(boolean)`
- `Serializer(boolean preserveFormatting)` constructor

**Migration:** Use `prettyPrint = false` for formatting preservation (default behavior unchanged).

## Examples

### Raw Mode
```java
// Method 1: Convenience method
Serializer serializer = new Serializer(DomTripConfig.raw());

// Method 2: Manual configuration
Serializer serializer = new Serializer();
serializer.setPrettyPrint(true);
serializer.setLineEnding("");   // No line breaks
serializer.setIndentString(""); // No indentation

// Result: <root><child>content</child></root>
```

### Automatic Detection
```java
// Raw XML - automatically detected and preserved
String rawXml = "<root><child>content</child></root>";
Document doc = Document.of(rawXml);
Editor editor = new Editor(doc);
editor.addElement(editor.root(), "new", "element");
// Result: <root><child>content</child><new>element</new></root>
```

## Testing

✅ All existing tests pass  
✅ New comprehensive test suite added  
✅ Backward compatibility maintained (except removed methods)  
✅ Performance impact minimal  

## Addresses

This PR addresses the original question about ensuring raw formatting is preserved when adding nodes to unformatted XML. The system now automatically detects raw formatting and sets `lineEnding = ""` and `indentString = ""` to maintain consistency.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author