### PR TITLE
Add empty element style configuration support

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/DomTripConfig.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DomTripConfig.java
@@ -32,7 +32,8 @@ package eu.maveniverse.domtrip;
  *
  * // Custom configuration
  * DomTripConfig custom = DomTripConfig.defaults()
- *     .withDefaultQuoteStyle(QuoteStyle.SINGLE);
+ *     .withDefaultQuoteStyle(QuoteStyle.SINGLE)
+ *     .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
  * }</pre>
  *
  * <h3>Builder Pattern:</h3>
@@ -42,18 +43,22 @@ package eu.maveniverse.domtrip;
  *     .withCommentPreservation(true)
  *     .withPrettyPrint(false)
  *     .withIndentString("    ")
- *     .withDefaultQuoteStyle(QuoteStyle.SINGLE);
+ *     .withDefaultQuoteStyle(QuoteStyle.SINGLE)
+ *     .withEmptyElementStyle(EmptyElementStyle.EXPANDED);
  * }</pre>
  *
  * @see Editor
  * @see Parser
  * @see Serializer
  * @see QuoteStyle
+ * @see EmptyElementStyle
  */
 public class DomTripConfig {
     private boolean preserveComments = true;
     private boolean preserveProcessingInstructions = true;
     private QuoteStyle defaultQuoteStyle = QuoteStyle.DOUBLE;
+    private EmptyElementStyle emptyElementStyle = EmptyElementStyle.SELF_CLOSING;
+    private boolean forceEmptyElementStyle = false;
     private boolean prettyPrint = false;
     private String indentString = "    ";
     private String lineEnding = "\n";
@@ -139,6 +144,28 @@ public class DomTripConfig {
         return this;
     }
 
+    public DomTripConfig withEmptyElementStyle(EmptyElementStyle emptyElementStyle) {
+        this.emptyElementStyle = emptyElementStyle;
+        return this;
+    }
+
+    /**
+     * Automatically detects and configures the empty element style based on existing
+     * empty elements in the provided document.
+     *
+     * <p>This method analyzes all empty elements in the document to determine the
+     * predominant style and configures this DomTripConfig to use that style.
+     * If no empty elements are found, the current style is preserved.</p>
+     *
+     * @param document the document to analyze for empty element styles
+     * @return this DomTripConfig for method chaining
+     */
+    public DomTripConfig withAutoDetectedEmptyElementStyle(Document document) {
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(document);
+        this.emptyElementStyle = detected;
+        return this;
+    }
+
     // Getters
     public boolean isPreserveComments() {
         return preserveComments;
@@ -150,6 +177,10 @@ public class DomTripConfig {
 
     public QuoteStyle defaultQuoteStyle() {
         return defaultQuoteStyle;
+    }
+
+    public EmptyElementStyle emptyElementStyle() {
+        return emptyElementStyle;
     }
 
     public boolean isPrettyPrint() {

--- a/core/src/main/java/eu/maveniverse/domtrip/EmptyElementStyle.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/EmptyElementStyle.java
@@ -1,0 +1,196 @@
+package eu.maveniverse.domtrip;
+
+/**
+ * Enumeration for XML empty element formatting styles.
+ *
+ * <p>XML empty elements can be written in three different styles according to the XML specification.
+ * DomTrip can automatically detect the existing style in a document and preserve it, or you can
+ * explicitly configure which style to use for new empty elements.</p>
+ *
+ * <h3>Style Examples:</h3>
+ * <ul>
+ *   <li><strong>EXPANDED</strong> - {@code <element></element>} (separate opening and closing tags)</li>
+ *   <li><strong>SELF_CLOSING</strong> - {@code <element/>} (self-closing tag without space)</li>
+ *   <li><strong>SELF_CLOSING_SPACED</strong> - {@code <element />} (self-closing tag with space)</li>
+ * </ul>
+ *
+ * <h3>Auto-Detection:</h3>
+ * <p>When parsing existing XML documents, DomTrip can automatically detect the predominant
+ * empty element style and use it for new empty elements. This ensures consistency with
+ * the existing document formatting.</p>
+ *
+ * <h3>Usage Examples:</h3>
+ * <pre>{@code
+ * // Configure explicit style
+ * DomTripConfig config = DomTripConfig.defaults()
+ *     .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+ *
+ * // Create element that will use configured style when empty
+ * Element element = Element.of("placeholder");
+ * // When serialized: <placeholder />
+ *
+ * // Auto-detect from existing document
+ * Document doc = Document.of("<root><empty/><another/></root>");
+ * EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(doc);
+ * // Returns: SELF_CLOSING
+ * }</pre>
+ *
+ * <h3>XML Specification Compliance:</h3>
+ * <p>All three styles are valid according to the XML specification. The choice between
+ * them is typically a matter of style preference, tool conventions, or organizational
+ * standards.</p>
+ *
+ * @see DomTripConfig#withEmptyElementStyle(EmptyElementStyle)
+ * @see Element
+ * @see Serializer
+ */
+public enum EmptyElementStyle {
+    /**
+     * Expanded form with separate opening and closing tags.
+     * <p>Example: {@code <element></element>}</p>
+     * <p>This style is more verbose but may be preferred in some contexts
+     * for clarity or compatibility with older XML processors.</p>
+     */
+    EXPANDED,
+
+    /**
+     * Self-closing tag without space before the slash.
+     * <p>Example: {@code <element/>}</p>
+     * <p>This is the most compact form and is commonly used in modern XML.</p>
+     */
+    SELF_CLOSING,
+
+    /**
+     * Self-closing tag with space before the slash.
+     * <p>Example: {@code <element />}</p>
+     * <p>This style is often preferred for better readability and is
+     * compatible with XHTML conventions.</p>
+     */
+    SELF_CLOSING_SPACED;
+
+    /**
+     * Detects the predominant empty element style used in a document.
+     *
+     * <p>This method analyzes all empty elements in the document and returns
+     * the most commonly used style. If no empty elements are found, or if
+     * there's a tie between styles, it returns {@link #SELF_CLOSING} as the default.</p>
+     *
+     * @param document the document to analyze
+     * @return the detected empty element style, or SELF_CLOSING if none detected
+     */
+    public static EmptyElementStyle detectFromDocument(Document document) {
+        if (document == null || document.root() == null) {
+            return SELF_CLOSING;
+        }
+
+        int expandedCount = 0;
+        int selfClosingCount = 0;
+        int selfClosingSpacedCount = 0;
+
+        // Recursively analyze all elements in the document
+        EmptyElementStyleCounter counter = new EmptyElementStyleCounter();
+        analyzeElement(document.root(), counter);
+
+        expandedCount = counter.expandedCount;
+        selfClosingCount = counter.selfClosingCount;
+        selfClosingSpacedCount = counter.selfClosingSpacedCount;
+
+        // Return the most common style, with SELF_CLOSING as default
+        if (expandedCount > selfClosingCount && expandedCount > selfClosingSpacedCount) {
+            return EXPANDED;
+        } else if (selfClosingSpacedCount > selfClosingCount && selfClosingSpacedCount > expandedCount) {
+            return SELF_CLOSING_SPACED;
+        } else {
+            return SELF_CLOSING;
+        }
+    }
+
+    /**
+     * Helper method to recursively analyze elements for empty element styles.
+     */
+    private static void analyzeElement(Element element, EmptyElementStyleCounter counter) {
+        // Check if this element is empty (no child nodes)
+        if (element.nodeCount() == 0) {
+            // Analyze the original formatting to determine style
+            String originalTag = element.originalOpenTag();
+            if (!originalTag.isEmpty()) {
+                if (element.selfClosing()) {
+                    // Check for space before />
+                    if (originalTag.endsWith(" />")) {
+                        counter.selfClosingSpacedCount++;
+                    } else if (originalTag.endsWith("/>")) {
+                        counter.selfClosingCount++;
+                    }
+                } else {
+                    // Has separate closing tag
+                    counter.expandedCount++;
+                }
+            } else {
+                // No original formatting available, check current state
+                if (element.selfClosing()) {
+                    // Default to SELF_CLOSING if no space information available
+                    counter.selfClosingCount++;
+                } else {
+                    counter.expandedCount++;
+                }
+            }
+        }
+
+        // Recursively analyze child elements
+        for (Node child : element.nodes().toList()) {
+            if (child instanceof Element) {
+                analyzeElement((Element) child, counter);
+            }
+        }
+    }
+
+    /**
+     * Helper class to count different empty element styles.
+     */
+    private static class EmptyElementStyleCounter {
+        int expandedCount = 0;
+        int selfClosingCount = 0;
+        int selfClosingSpacedCount = 0;
+    }
+
+    /**
+     * Formats an empty element according to this style.
+     *
+     * @param elementName the name of the element
+     * @param attributes the attributes string (may be empty)
+     * @return the formatted empty element string
+     */
+    public String format(String elementName, String attributes) {
+        String attrString = attributes.isEmpty() ? "" : " " + attributes.trim();
+
+        switch (this) {
+            case EXPANDED:
+                return "<" + elementName + attrString + "></" + elementName + ">";
+            case SELF_CLOSING:
+                return "<" + elementName + attrString + "/>";
+            case SELF_CLOSING_SPACED:
+                return "<" + elementName + attrString + " />";
+            default:
+                return "<" + elementName + attrString + "/>";
+        }
+    }
+
+    /**
+     * Returns a human-readable description of this style.
+     *
+     * @return a description of the empty element style
+     */
+    @Override
+    public String toString() {
+        switch (this) {
+            case EXPANDED:
+                return "expanded (<element></element>)";
+            case SELF_CLOSING:
+                return "self-closing (<element/>)";
+            case SELF_CLOSING_SPACED:
+                return "self-closing with space (<element />)";
+            default:
+                return "unknown";
+        }
+    }
+}

--- a/core/src/test/java/eu/maveniverse/domtrip/EmptyElementStyleTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/EmptyElementStyleTest.java
@@ -1,0 +1,624 @@
+package eu.maveniverse.domtrip;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for empty element style configuration and auto-detection functionality.
+ */
+public class EmptyElementStyleTest {
+
+    @Test
+    void testEmptyElementStyleEnum() {
+        // Test enum values
+        assertEquals(3, EmptyElementStyle.values().length);
+
+        // Test toString methods
+        assertTrue(EmptyElementStyle.EXPANDED.toString().contains("expanded"));
+        assertTrue(EmptyElementStyle.SELF_CLOSING.toString().contains("self-closing"));
+        assertTrue(EmptyElementStyle.SELF_CLOSING_SPACED.toString().contains("self-closing with space"));
+    }
+
+    @Test
+    void testEmptyElementStyleFormatting() {
+        String elementName = "test";
+        String attributes = "id=\"123\" class=\"example\"";
+
+        // Test EXPANDED style
+        String expanded = EmptyElementStyle.EXPANDED.format(elementName, attributes);
+        assertEquals("<test id=\"123\" class=\"example\"></test>", expanded);
+
+        // Test SELF_CLOSING style
+        String selfClosing = EmptyElementStyle.SELF_CLOSING.format(elementName, attributes);
+        assertEquals("<test id=\"123\" class=\"example\"/>", selfClosing);
+
+        // Test SELF_CLOSING_SPACED style
+        String selfClosingSpaced = EmptyElementStyle.SELF_CLOSING_SPACED.format(elementName, attributes);
+        assertEquals("<test id=\"123\" class=\"example\" />", selfClosingSpaced);
+
+        // Test with no attributes
+        String expandedNoAttrs = EmptyElementStyle.EXPANDED.format(elementName, "");
+        assertEquals("<test></test>", expandedNoAttrs);
+
+        String selfClosingNoAttrs = EmptyElementStyle.SELF_CLOSING.format(elementName, "");
+        assertEquals("<test/>", selfClosingNoAttrs);
+
+        String selfClosingSpacedNoAttrs = EmptyElementStyle.SELF_CLOSING_SPACED.format(elementName, "");
+        assertEquals("<test />", selfClosingSpacedNoAttrs);
+    }
+
+    @Test
+    void testAutoDetectionWithSelfClosingElements() {
+        String xml =
+                """
+            <root>
+                <empty1/>
+                <empty2/>
+                <empty3/>
+                <nonempty>content</nonempty>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(doc);
+        assertEquals(EmptyElementStyle.SELF_CLOSING, detected);
+    }
+
+    @Test
+    void testAutoDetectionWithSelfClosingSpacedElements() {
+        String xml =
+                """
+            <root>
+                <empty1 />
+                <empty2 />
+                <empty3 />
+                <nonempty>content</nonempty>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(doc);
+        assertEquals(EmptyElementStyle.SELF_CLOSING_SPACED, detected);
+    }
+
+    @Test
+    void testAutoDetectionWithExpandedElements() {
+        String xml =
+                """
+            <root>
+                <empty1></empty1>
+                <empty2></empty2>
+                <empty3></empty3>
+                <nonempty>content</nonempty>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(doc);
+        assertEquals(EmptyElementStyle.EXPANDED, detected);
+    }
+
+    @Test
+    void testAutoDetectionWithMixedStyles() {
+        // When there's a tie or mixed styles, should default to SELF_CLOSING
+        String xml =
+                """
+            <root>
+                <empty1/>
+                <empty2></empty2>
+                <nonempty>content</nonempty>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(doc);
+        assertEquals(EmptyElementStyle.SELF_CLOSING, detected);
+    }
+
+    @Test
+    void testAutoDetectionWithNoEmptyElements() {
+        String xml =
+                """
+            <root>
+                <child1>content1</child1>
+                <child2>content2</child2>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(doc);
+        assertEquals(EmptyElementStyle.SELF_CLOSING, detected); // Default when no empty elements
+    }
+
+    @Test
+    void testAutoDetectionWithNullDocument() {
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(null);
+        assertEquals(EmptyElementStyle.SELF_CLOSING, detected);
+    }
+
+    @Test
+    void testDomTripConfigWithEmptyElementStyle() {
+        // Test default configuration
+        DomTripConfig defaultConfig = DomTripConfig.defaults();
+        assertEquals(EmptyElementStyle.SELF_CLOSING, defaultConfig.emptyElementStyle());
+
+        // Test explicit configuration
+        DomTripConfig customConfig = DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+        assertEquals(EmptyElementStyle.EXPANDED, customConfig.emptyElementStyle());
+
+        // Test fluent configuration
+        DomTripConfig fluentConfig = DomTripConfig.prettyPrint()
+                .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED)
+                .withIndentString("  ");
+        assertEquals(EmptyElementStyle.SELF_CLOSING_SPACED, fluentConfig.emptyElementStyle());
+    }
+
+    @Test
+    void testDomTripConfigAutoDetection() {
+        String xml =
+                """
+            <root>
+                <empty1 />
+                <empty2 />
+                <child>content</child>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+        DomTripConfig config = DomTripConfig.defaults().withAutoDetectedEmptyElementStyle(doc);
+
+        assertEquals(EmptyElementStyle.SELF_CLOSING_SPACED, config.emptyElementStyle());
+    }
+
+    @Test
+    void testSerializerWithEmptyElementStyle() {
+        // Test that Serializer respects the empty element style configuration
+        DomTripConfig config = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+
+        Serializer serializer = new Serializer(config);
+        assertEquals(EmptyElementStyle.EXPANDED, serializer.getEmptyElementStyle());
+
+        // Test setter
+        serializer.setEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+        assertEquals(EmptyElementStyle.SELF_CLOSING_SPACED, serializer.getEmptyElementStyle());
+
+        // Test null handling
+        serializer.setEmptyElementStyle(null);
+        assertEquals(EmptyElementStyle.SELF_CLOSING, serializer.getEmptyElementStyle());
+    }
+
+    @Test
+    void testPrettyPrintSerializationWithExpandedStyle() {
+        Document doc = Document.withRootElement("root");
+        Element root = doc.root();
+
+        // Add an empty element
+        Element empty = Element.of("empty");
+        root.addNode(empty);
+
+        // Configure for expanded style
+        DomTripConfig config = DomTripConfig.prettyPrint()
+                .withEmptyElementStyle(EmptyElementStyle.EXPANDED)
+                .withIndentString("  ");
+
+        Serializer serializer = new Serializer(config);
+        String result = serializer.serialize(doc);
+
+        // Should contain expanded empty element
+        assertTrue(result.contains("<empty></empty>"), "Should contain expanded empty element, but got: " + result);
+    }
+
+    @Test
+    void testPrettyPrintSerializationWithSelfClosingStyle() {
+        Document doc = Document.withRootElement("root");
+        Element root = doc.root();
+
+        // Add an empty element
+        Element empty = Element.of("empty");
+        root.addNode(empty);
+
+        // Configure for self-closing style
+        DomTripConfig config = DomTripConfig.prettyPrint()
+                .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING)
+                .withIndentString("  ");
+
+        Serializer serializer = new Serializer(config);
+        String result = serializer.serialize(doc);
+
+        // Should contain self-closing empty element
+        assertTrue(result.contains("<empty/>"), "Should contain self-closing empty element, but got: " + result);
+    }
+
+    @Test
+    void testPrettyPrintSerializationWithSelfClosingSpacedStyle() {
+        Document doc = Document.withRootElement("root");
+        Element root = doc.root();
+
+        // Add an empty element
+        Element empty = Element.of("empty");
+        root.addNode(empty);
+
+        // Configure for self-closing spaced style
+        DomTripConfig config = DomTripConfig.prettyPrint()
+                .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED)
+                .withIndentString("  ");
+
+        Serializer serializer = new Serializer(config);
+        String result = serializer.serialize(doc);
+
+        // Should contain self-closing spaced empty element
+        assertTrue(
+                result.contains("<empty />"), "Should contain self-closing spaced empty element, but got: " + result);
+    }
+
+    @Test
+    void testEmptyElementWithAttributes() {
+        Document doc = Document.withRootElement("root");
+        Element root = doc.root();
+
+        // Add an empty element with attributes
+        Element empty = Element.of("empty");
+        empty.attribute("id", "test");
+        empty.attribute("class", "example");
+        root.addNode(empty);
+
+        // Test different styles
+        DomTripConfig expandedConfig = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+        String expandedResult = new Serializer(expandedConfig).serialize(doc);
+        assertTrue(expandedResult.contains("<empty id=\"test\" class=\"example\"></empty>"));
+
+        DomTripConfig selfClosingConfig =
+                DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING);
+        String selfClosingResult = new Serializer(selfClosingConfig).serialize(doc);
+        assertTrue(selfClosingResult.contains("<empty id=\"test\" class=\"example\"/>"));
+
+        DomTripConfig spacedConfig =
+                DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+        String spacedResult = new Serializer(spacedConfig).serialize(doc);
+        assertTrue(spacedResult.contains("<empty id=\"test\" class=\"example\" />"));
+    }
+
+    @Test
+    void testNonPrettyPrintPreservesOriginalFormatting() {
+        // Test that empty element style configuration doesn't affect existing formatting
+        // when pretty print is disabled
+        String originalXml =
+                """
+            <root>
+                <expanded></expanded>
+                <selfClosing/>
+                <selfClosingSpaced />
+                <mixed attr="value"/>
+                <child>content</child>
+            </root>
+            """;
+
+        Document doc = Document.of(originalXml);
+
+        // Configure different empty element styles but disable pretty print
+        DomTripConfig expandedConfig = DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+        String expandedResult = new Serializer(expandedConfig).serialize(doc);
+
+        DomTripConfig selfClosingConfig =
+                DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING);
+        String selfClosingResult = new Serializer(selfClosingConfig).serialize(doc);
+
+        DomTripConfig spacedConfig =
+                DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+        String spacedResult = new Serializer(spacedConfig).serialize(doc);
+
+        // All results should be identical to original XML regardless of empty element style config
+        assertEquals(originalXml, expandedResult, "EXPANDED config should preserve original formatting");
+        assertEquals(originalXml, selfClosingResult, "SELF_CLOSING config should preserve original formatting");
+        assertEquals(originalXml, spacedResult, "SELF_CLOSING_SPACED config should preserve original formatting");
+
+        // Verify specific original formatting is preserved
+        assertTrue(expandedResult.contains("<expanded></expanded>"));
+        assertTrue(expandedResult.contains("<selfClosing/>"));
+        assertTrue(expandedResult.contains("<selfClosingSpaced />"));
+        assertTrue(expandedResult.contains("<mixed attr=\"value\"/>"));
+    }
+
+    @Test
+    void testNonPrettyPrintPreservesOriginalFormattingAfterModification() {
+        // Test that only modified elements use the empty element style configuration
+        String originalXml =
+                """
+            <root>
+                <existing/>
+                <another />
+                <child>content</child>
+            </root>
+            """;
+
+        Document doc = Document.of(originalXml);
+
+        // Add a new empty element
+        Element newEmpty = Element.of("newElement");
+        doc.root().addNode(newEmpty);
+
+        // Configure for expanded style but disable pretty print
+        DomTripConfig config = DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+        String result = new Serializer(config).serialize(doc);
+
+        // Original elements should preserve their formatting
+        assertTrue(result.contains("<existing/>"), "Original self-closing should be preserved");
+        assertTrue(result.contains("<another />"), "Original spaced self-closing should be preserved");
+        assertTrue(result.contains("<child>content</child>"), "Non-empty element should be preserved");
+
+        // New element should use the configured style (expanded)
+        assertTrue(result.contains("<newElement></newElement>"), "New element should use configured style");
+    }
+
+    @Test
+    void testNonPrettyPrintWithMixedOriginalStyles() {
+        // Test preservation of various original empty element styles
+        String originalXml =
+                """
+            <project>
+                <groupId>com.example</groupId>
+                <artifactId>test</artifactId>
+                <version>1.0</version>
+                <properties>
+                    <maven.compiler.source>17</maven.compiler.source>
+                    <maven.compiler.target>17</maven.compiler.target>
+                    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                </properties>
+                <dependencies>
+                    <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.2</version>
+                        <scope>test</scope>
+                        <exclusions/>
+                    </dependency>
+                </dependencies>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>3.11.0</version>
+                            <configuration />
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """;
+
+        Document doc = Document.of(originalXml);
+
+        // Test with different empty element style configurations
+        DomTripConfig[] configs = {
+            DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.EXPANDED),
+            DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING),
+            DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED)
+        };
+
+        for (DomTripConfig config : configs) {
+            String result = new Serializer(config).serialize(doc);
+
+            // All original formatting should be preserved regardless of config
+            assertEquals(
+                    originalXml,
+                    result,
+                    "Original formatting should be preserved with config: " + config.emptyElementStyle());
+
+            // Verify specific elements maintain their original style
+            assertTrue(result.contains("<exclusions/>"), "Self-closing without space should be preserved");
+            assertTrue(result.contains("<configuration />"), "Self-closing with space should be preserved");
+        }
+    }
+
+    @Test
+    void testNonEmptyElementsUnaffected() {
+        Document doc = Document.withRootElement("root");
+        Element root = doc.root();
+
+        // Add a non-empty element
+        Element nonEmpty = Element.of("child");
+        nonEmpty.textContent("some content");
+        root.addNode(nonEmpty);
+
+        // Configure for expanded style
+        DomTripConfig config = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+
+        Serializer serializer = new Serializer(config);
+        String result = serializer.serialize(doc);
+
+        // Non-empty elements should not be affected by empty element style
+        assertTrue(result.contains("<child>some content</child>"));
+        assertFalse(result.contains("<child></child>"));
+    }
+
+    @Test
+    void testNestedEmptyElements() {
+        Document doc = Document.withRootElement("root");
+        Element root = doc.root();
+
+        // Add nested structure with empty elements
+        Element parent = Element.of("parent");
+        Element empty1 = Element.of("empty1");
+        Element empty2 = Element.of("empty2");
+
+        parent.addNode(empty1);
+        parent.addNode(empty2);
+        root.addNode(parent);
+
+        // Configure for self-closing spaced style
+        DomTripConfig config = DomTripConfig.prettyPrint()
+                .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED)
+                .withIndentString("  ");
+
+        Serializer serializer = new Serializer(config);
+        String result = serializer.serialize(doc);
+
+        // Both nested empty elements should use the configured style
+        assertTrue(result.contains("<empty1 />"));
+        assertTrue(result.contains("<empty2 />"));
+        // Parent should not be affected as it has content
+        assertTrue(result.contains("<parent>"));
+        assertTrue(result.contains("</parent>"));
+    }
+
+    @Test
+    void testAutoDetectionWithNestedEmptyElements() {
+        String xml =
+                """
+            <root>
+                <parent>
+                    <empty1/>
+                    <empty2/>
+                    <child>content</child>
+                </parent>
+                <empty3/>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+        EmptyElementStyle detected = EmptyElementStyle.detectFromDocument(doc);
+        assertEquals(EmptyElementStyle.SELF_CLOSING, detected);
+    }
+
+    @Test
+    void testRoundTripPreservation() {
+        // Test that parsing and re-serializing preserves the detected style
+        String originalXml =
+                """
+            <root>
+                <empty1 />
+                <empty2 />
+                <child>content</child>
+            </root>
+            """;
+
+        Document doc = Document.of(originalXml);
+
+        // Auto-detect and configure
+        DomTripConfig config = DomTripConfig.prettyPrint()
+                .withAutoDetectedEmptyElementStyle(doc)
+                .withIndentString("    ");
+
+        Serializer serializer = new Serializer(config);
+        String result = serializer.serialize(doc);
+
+        // Should preserve the spaced self-closing style
+        assertTrue(result.contains("<empty1 />"));
+        assertTrue(result.contains("<empty2 />"));
+    }
+
+    @Test
+    void testEditorIntegration() {
+        // Test that Editor respects empty element style configuration
+        Document doc = Document.withRootElement("root");
+        DomTripConfig config = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+
+        Editor editor = new Editor(doc, config);
+
+        // Add an empty element through Editor
+        editor.addElement(editor.root(), "placeholder");
+
+        String result = editor.toXml();
+
+        // Should use expanded style for the empty element
+        assertTrue(result.contains("<placeholder></placeholder>"));
+    }
+
+    @Test
+    void testMixedContentWithEmptyElements() {
+        Document doc = Document.withRootElement("root");
+        Element root = doc.root();
+
+        // Create mixed content: text, empty elements, and non-empty elements
+        root.addNode(Text.of("  "));
+        root.addNode(Element.of("empty1"));
+        root.addNode(Text.of("  "));
+        root.addNode(Element.text("nonempty", "content"));
+        root.addNode(Text.of("  "));
+        root.addNode(Element.of("empty2"));
+        root.addNode(Text.of("  "));
+
+        DomTripConfig config = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+
+        String result = new Serializer(config).serialize(doc);
+
+        // Empty elements should use configured style
+        assertTrue(result.contains("<empty1 />"));
+        assertTrue(result.contains("<empty2 />"));
+        // Non-empty element should be unaffected
+        assertTrue(result.contains("<nonempty>content</nonempty>"));
+    }
+
+    @Test
+    void testEmptyElementStyleOnlyAffectsPrettyPrint() {
+        // Verify that empty element style configuration only affects pretty print mode
+        String originalXml =
+                """
+            <root>
+                <empty1/>
+                <empty2 />
+                <empty3></empty3>
+            </root>
+            """;
+
+        Document doc = Document.of(originalXml);
+
+        // Test with pretty print disabled (default)
+        DomTripConfig nonPrettyConfig = DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+        String nonPrettyResult = new Serializer(nonPrettyConfig).serialize(doc);
+
+        // Should preserve original formatting exactly
+        assertEquals(originalXml, nonPrettyResult);
+
+        // Test with pretty print enabled
+        DomTripConfig prettyConfig = DomTripConfig.prettyPrint()
+                .withEmptyElementStyle(EmptyElementStyle.EXPANDED)
+                .withIndentString("    ");
+        String prettyResult = new Serializer(prettyConfig).serialize(doc);
+
+        // Should apply the configured empty element style
+        assertTrue(prettyResult.contains("<empty1></empty1>"));
+        assertTrue(prettyResult.contains("<empty2></empty2>"));
+        assertTrue(prettyResult.contains("<empty3></empty3>"));
+
+        // Should not match original formatting
+        assertNotEquals(originalXml, prettyResult);
+    }
+
+    @Test
+    void testOriginalFormattingPreservedWithEditor() {
+        // Test that Editor preserves original formatting for unmodified elements
+        String originalXml =
+                """
+            <config>
+                <setting1/>
+                <setting2 />
+                <setting3></setting3>
+                <value>content</value>
+            </config>
+            """;
+
+        Document doc = Document.of(originalXml);
+
+        // Configure for different empty element style
+        DomTripConfig config = DomTripConfig.defaults().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+
+        Editor editor = new Editor(doc, config);
+
+        // Add a new empty element (should use configured style)
+        editor.addElement(editor.root(), "newSetting");
+
+        String result = editor.toXml();
+
+        // Original elements should preserve their formatting
+        assertTrue(result.contains("<setting1/>"), "Original self-closing should be preserved");
+        assertTrue(result.contains("<setting2 />"), "Original spaced self-closing should be preserved");
+        assertTrue(result.contains("<setting3></setting3>"), "Original expanded should be preserved");
+        assertTrue(result.contains("<value>content</value>"), "Non-empty element should be preserved");
+
+        // New element should use configured style (but only in pretty print mode)
+        // Since we're not using pretty print, new element uses default Element.toXml()
+        assertTrue(result.contains("<newSetting></newSetting>") || result.contains("<newSetting/>"));
+    }
+}

--- a/core/src/test/java/eu/maveniverse/domtrip/snippets/ConfigurationSnippets.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/snippets/ConfigurationSnippets.java
@@ -259,6 +259,88 @@ public class ConfigurationSnippets extends BaseSnippetTest {
         Assertions.assertNotNull(config);
     }
 
+    @Test
+    public void demonstrateEmptyElementStyles() {
+        // START: empty-element-styles
+        // Configure different empty element styles
+
+        // Expanded form: <element></element>
+        DomTripConfig expanded = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+
+        // Self-closing: <element/>
+        DomTripConfig selfClosing = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING);
+
+        // Self-closing with space: <element />
+        DomTripConfig selfClosingSpaced =
+                DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+        // END: empty-element-styles
+
+        Assertions.assertEquals(EmptyElementStyle.EXPANDED, expanded.emptyElementStyle());
+        Assertions.assertEquals(EmptyElementStyle.SELF_CLOSING, selfClosing.emptyElementStyle());
+        Assertions.assertEquals(EmptyElementStyle.SELF_CLOSING_SPACED, selfClosingSpaced.emptyElementStyle());
+    }
+
+    @Test
+    public void demonstrateEmptyElementAutoDetection() {
+        // START: empty-element-auto-detection
+        // XML with self-closing spaced empty elements
+        String xml =
+                """
+            <root>
+                <empty1 />
+                <empty2 />
+                <child>content</child>
+            </root>
+            """;
+
+        Document doc = Document.of(xml);
+
+        // Auto-detect and apply the detected style
+        DomTripConfig config = DomTripConfig.prettyPrint().withAutoDetectedEmptyElementStyle(doc);
+
+        // The configuration will now use SELF_CLOSING_SPACED for new empty elements
+        Serializer serializer = new Serializer(config);
+
+        // Add a new empty element
+        Element newEmpty = Element.of("placeholder");
+        doc.root().addNode(newEmpty);
+
+        String result = serializer.serialize(doc);
+        // New empty element will use the detected style: <placeholder />
+        // END: empty-element-auto-detection
+
+        Assertions.assertEquals(EmptyElementStyle.SELF_CLOSING_SPACED, config.emptyElementStyle());
+        Assertions.assertTrue(result.contains("<placeholder />"));
+    }
+
+    @Test
+    public void demonstrateEmptyElementStyleComparison() {
+        // START: empty-element-style-comparison
+        Document doc = Document.withRootElement("root");
+        Element empty = Element.of("empty");
+        doc.root().addNode(empty);
+
+        // Test different styles
+        DomTripConfig expandedConfig = DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+        String expandedResult = new Serializer(expandedConfig).serialize(doc);
+        // Result: <empty></empty>
+
+        DomTripConfig selfClosingConfig =
+                DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING);
+        String selfClosingResult = new Serializer(selfClosingConfig).serialize(doc);
+        // Result: <empty/>
+
+        DomTripConfig spacedConfig =
+                DomTripConfig.prettyPrint().withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+        String spacedResult = new Serializer(spacedConfig).serialize(doc);
+        // Result: <empty />
+        // END: empty-element-style-comparison
+
+        Assertions.assertTrue(expandedResult.contains("<empty></empty>"));
+        Assertions.assertTrue(selfClosingResult.contains("<empty/>"));
+        Assertions.assertTrue(spacedResult.contains("<empty />"));
+    }
+
     // Helper methods for environment-specific configurations example
     private static DomTripConfig forDevelopment() {
         return DomTripConfig.prettyPrint().withIndentString("  ").withCommentPreservation(true);

--- a/website/content/docs/api/configuration.md
+++ b/website/content/docs/api/configuration.md
@@ -239,6 +239,72 @@ DomTripConfig config = isProduction()
     : DomTripConfig.prettyPrint();                 // Readable for debugging
 ```
 
+## Empty Element Styles
+
+Control how empty XML elements are formatted during serialization:
+
+### Available Styles
+
+DomTrip supports three different empty element styles:
+
+```java
+// Expanded form: <element></element>
+DomTripConfig expanded = DomTripConfig.defaults()
+    .withEmptyElementStyle(EmptyElementStyle.EXPANDED);
+
+// Self-closing: <element/>
+DomTripConfig selfClosing = DomTripConfig.defaults()
+    .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING);
+
+// Self-closing with space: <element />
+DomTripConfig selfClosingSpaced = DomTripConfig.defaults()
+    .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);
+```
+
+### Auto-Detection
+
+Automatically detect the predominant empty element style from an existing document:
+
+```java
+Document doc = Document.of(xmlString);
+
+// Auto-detect and apply the detected style
+DomTripConfig config = DomTripConfig.defaults()
+    .withAutoDetectedEmptyElementStyle(doc);
+
+// The configuration will now use the detected style for new empty elements
+```
+
+### Style Examples
+
+```xml
+<!-- EXPANDED style -->
+<root>
+    <empty></empty>
+    <placeholder></placeholder>
+</root>
+
+<!-- SELF_CLOSING style -->
+<root>
+    <empty/>
+    <placeholder/>
+</root>
+
+<!-- SELF_CLOSING_SPACED style -->
+<root>
+    <empty />
+    <placeholder />
+</root>
+```
+
+### Behavior Notes
+
+- Empty element style only affects elements with no child nodes
+- Non-empty elements are unaffected by this setting
+- When pretty printing is disabled, original formatting is preserved when possible
+- Auto-detection analyzes all empty elements and uses the most common style
+- If no empty elements exist or there's a tie, defaults to `SELF_CLOSING`
+
 ## Available Configuration Methods
 
 Here's a complete list of available configuration methods:
@@ -256,7 +322,11 @@ DomTripConfig config = DomTripConfig.defaults()
     .withXmlDeclaration(boolean)                   // Include XML declaration
 
     // Attribute formatting
-    .withDefaultQuoteStyle(QuoteStyle);            // Default quote style for new attributes
+    .withDefaultQuoteStyle(QuoteStyle)             // Default quote style for new attributes
+
+    // Empty element formatting
+    .withEmptyElementStyle(EmptyElementStyle)      // Style for empty elements
+    .withAutoDetectedEmptyElementStyle(Document);  // Auto-detect style from document
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Implements configurable empty element styles for XML serialization as requested in issue #43.

## Features

- **EmptyElementStyle enum** with three styles:
  - `EXPANDED`: `<element></element>`
  - `SELF_CLOSING`: `<element/>`
  - `SELF_CLOSING_SPACED`: `<element />`
- **Auto-detection** of existing empty element styles from documents
- **DomTripConfig integration** with fluent configuration methods
- **Serializer support** for empty element style configuration in pretty print mode
- **Comprehensive test suite** with 26 test methods
- **Updated documentation** with examples and usage patterns

## Key Behaviors

- **Pretty print mode** applies configured style to ALL empty elements
- **Non-pretty print mode** preserves original formatting for unmodified elements
- **Auto-detection** analyzes existing documents and uses the most common style
- **Backward compatible** with existing code (default: `SELF_CLOSING`)

## Usage Examples

```java
// Configure empty element style
DomTripConfig config = DomTripConfig.prettyPrint()
    .withEmptyElementStyle(EmptyElementStyle.SELF_CLOSING_SPACED);

// Auto-detect from existing document
DomTripConfig autoConfig = DomTripConfig.prettyPrint()
    .withAutoDetectedEmptyElementStyle(document);

// Use with serializer
Serializer serializer = new Serializer(config);
String xml = serializer.serialize(document);
```

## Changes

- Add `EmptyElementStyle.java` enum with auto-detection capability
- Enhance `DomTripConfig` with empty element style configuration
- Update `Serializer` to respect empty element style in pretty print mode
- Add `EmptyElementStyleTest.java` with comprehensive test coverage
- Update `ConfigurationSnippets.java` with usage examples
- Update configuration documentation with new section

## Testing

- ✅ All 500+ existing tests pass
- ✅ 26 new tests specifically for empty element styles
- ✅ Full build successful with Maven
- ✅ Comprehensive preservation behavior tests

## Backward Compatibility

- ✅ No breaking changes to existing API
- ✅ Default behavior unchanged (`SELF_CLOSING`)
- ✅ All existing tests pass without modification

Resolves #43

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author