### PR TITLE
Fix documentation styling issues by adding layout property to all doc pages

### DIFF
--- a/website/content/docs/api/document.md
+++ b/website/content/docs/api/document.md
@@ -2,6 +2,7 @@
 title: "Document API"
 description: "Complete reference for the Document class and XML document management"
 weight: 30
+layout: page
 ---
 
 # Document API

--- a/website/content/docs/api/element.md
+++ b/website/content/docs/api/element.md
@@ -2,6 +2,7 @@
 title: "Element API"
 description: "Complete reference for the Element class and XML element manipulation"
 weight: 20
+layout: page
 ---
 
 # Element API

--- a/website/content/docs/features/commenting.md
+++ b/website/content/docs/features/commenting.md
@@ -2,6 +2,7 @@
 title: "Element Commenting"
 description: "Comment out and uncomment XML elements while preserving formatting"
 weight: 50
+layout: page
 ---
 
 # Element Commenting

--- a/website/content/docs/features/element-positioning.md
+++ b/website/content/docs/features/element-positioning.md
@@ -2,6 +2,7 @@
 title: "Element Positioning"
 description: "Insert XML elements at specific positions with precise control"
 weight: 60
+layout: page
 ---
 
 # Element Positioning

--- a/website/content/docs/features/error-handling.md
+++ b/website/content/docs/features/error-handling.md
@@ -2,6 +2,7 @@
 title: "Error Handling"
 description: "Comprehensive error handling and recovery strategies in DomTrip"
 weight: 80
+layout: page
 ---
 
 # Error Handling

--- a/website/content/docs/features/input-stream-parsing.md
+++ b/website/content/docs/features/input-stream-parsing.md
@@ -2,6 +2,7 @@
 title: "Input Stream Parsing"
 description: "Parse XML from InputStreams with automatic encoding detection"
 weight: 70
+layout: page
 ---
 
 # Input Stream Parsing

--- a/website/content/docs/features/performance.md
+++ b/website/content/docs/features/performance.md
@@ -2,6 +2,7 @@
 title: "Performance"
 description: "Performance characteristics and optimization strategies for DomTrip"
 weight: 90
+layout: page
 ---
 
 # Performance

--- a/website/content/docs/features/processing-instructions.md
+++ b/website/content/docs/features/processing-instructions.md
@@ -2,6 +2,7 @@
 title: "Processing Instructions"
 description: "Working with XML processing instructions in DomTrip"
 weight: 60
+layout: page
 ---
 
 # Processing Instructions

--- a/website/content/docs/maven/api.md
+++ b/website/content/docs/maven/api.md
@@ -1,6 +1,7 @@
 ---
 title: PomEditor API Reference
 description: Complete API reference for the PomEditor class and Maven extension
+layout: page
 ---
 
 # PomEditor API Reference

--- a/website/content/docs/maven/examples.md
+++ b/website/content/docs/maven/examples.md
@@ -1,6 +1,7 @@
 ---
 title: Maven Examples
 description: Real-world examples of using the DomTrip Maven extension
+layout: page
 ---
 
 # Maven Examples

--- a/website/content/docs/maven/index.md
+++ b/website/content/docs/maven/index.md
@@ -1,6 +1,7 @@
 ---
 title: Maven Extension
 description: DomTrip Maven extension for specialized POM file editing
+layout: page
 ---
 
 # Maven Extension

--- a/website/content/docs/maven/installation.md
+++ b/website/content/docs/maven/installation.md
@@ -1,6 +1,7 @@
 ---
 title: Maven Extension Installation
 description: How to install and configure the DomTrip Maven extension
+layout: page
 ---
 
 # Maven Extension Installation

--- a/website/content/docs/maven/ordering.md
+++ b/website/content/docs/maven/ordering.md
@@ -1,6 +1,7 @@
 ---
 title: Maven Element Ordering
 description: Understanding how PomEditor orders elements according to Maven conventions
+layout: page
 ---
 
 # Maven Element Ordering

--- a/website/content/docs/maven/overview.md
+++ b/website/content/docs/maven/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Maven Extension Overview
 description: Overview of DomTrip's Maven-specific extensions for POM file editing
+layout: page
 ---
 
 # Maven Extension Overview

--- a/website/content/docs/maven/quick-start.md
+++ b/website/content/docs/maven/quick-start.md
@@ -1,6 +1,7 @@
 ---
 title: Maven Quick Start
 description: Get started with DomTrip Maven extension in 5 minutes
+layout: page
 ---
 
 # Maven Quick Start


### PR DESCRIPTION
## Description

This PR fixes issue #76 where some documentation pages were not displaying syntax highlighting properly and had inconsistent themes.

## Root Cause

The problem was that pages without an explicit `layout: page` property in their frontmatter were using ROQ's default layout, which doesn't include Prism.js for syntax highlighting. This caused:

1. **Code blocks to appear without syntax highlighting** - The default ROQ layout doesn't load Prism.js CSS or JavaScript
2. **Different themes between pages** - Pages with `layout: page` (like introduction.md) loaded the custom layout with Prism.js, while pages without it used the default ROQ theme

## Changes

- Added `layout: page` to the frontmatter of 15 documentation markdown files that were missing it
- This ensures all documentation pages use the custom `page.html` layout which includes:
  - Prism.js CSS for syntax highlighting themes
  - Prism.js JavaScript for code highlighting
  - Consistent navigation and styling

## Files Updated

**API Documentation:**
- `website/content/docs/api/document.md`
- `website/content/docs/api/element.md`

**Features Documentation:**
- `website/content/docs/features/commenting.md`
- `website/content/docs/features/element-positioning.md`
- `website/content/docs/features/error-handling.md`
- `website/content/docs/features/input-stream-parsing.md`
- `website/content/docs/features/performance.md`
- `website/content/docs/features/processing-instructions.md`

**Maven Extension Documentation:**
- `website/content/docs/maven/api.md`
- `website/content/docs/maven/examples.md`
- `website/content/docs/maven/index.md`
- `website/content/docs/maven/installation.md`
- `website/content/docs/maven/ordering.md`
- `website/content/docs/maven/overview.md`
- `website/content/docs/maven/quick-start.md`

## Testing

Tested locally by building the static site and confirming that:
- All pages now load Prism.js CSS and JavaScript
- Code blocks have proper `language-*` classes
- Syntax highlighting works correctly on all documentation pages
- Consistent theme across all documentation pages

## Screenshots

### Before
Pages like `/docs/maven/installation/` had no syntax highlighting and used the default ROQ theme.

### After
All documentation pages now have proper syntax highlighting and use the consistent custom theme.

Fixes #76

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author