### PR TITLE
Configure quarkus web bundles node_modules dir under target/ instead of root

### DIFF
--- a/website/src/main/resources/application.properties
+++ b/website/src/main/resources/application.properties
@@ -4,6 +4,9 @@
 quarkus.roq.generator.output-dir=dist
 quarkus.roq.generator.batch=false
 
+# Web Bundler Configuration - node_modules location
+quarkus.web-bundler.node-modules=target
+
 # Link validation configuration
 domtrip.links.validate=true
 domtrip.links.fail-on-broken=true


### PR DESCRIPTION
After upgrading to Quarkus 3.31.2 and Quarkus-ROQ 2.0.4, the Web Bundler 2.0+ automatically creates a node_modules directory in the website module root during builds.

The new property configures Web Bundler to create it under target/ so is ignored by git and clean by mvn clean