### PR TITLE
fix: escape Qute expressions in docs and add GitHub link to homepage

### DIFF
--- a/website/content/docs/advanced/migration.md
+++ b/website/content/docs/advanced/migration.md
@@ -175,7 +175,7 @@ container.nodeAt(0);
 container.nodeCount();
 
 // NEW: ContainerNode child access
-container.childAt(0);
+container.child(0);
 container.childCount();
 ```
 

--- a/website/content/docs/maven/alignment.md
+++ b/website/content/docs/maven/alignment.md
@@ -23,7 +23,7 @@ DomTrip analyzes your POM to detect three aspects of your dependency versioning 
 | Convention | Values | Description |
 |-----------|--------|-------------|
 | **VersionStyle** | `INLINE`, `MANAGED` | Whether versions are on dependencies directly or in `<dependencyManagement>` |
-| **VersionSource** | `LITERAL`, `PROPERTY` | Whether versions are literal values (`5.9.2`) or property references (`${junit.version}`) |
+| **VersionSource** | `LITERAL`, `PROPERTY` | Whether versions are literal values (`5.9.2`) or property references (`$\{junit.version}`) |
 | **PropertyNamingConvention** | `DOT_SUFFIX`, `DASH_SUFFIX`, `CAMEL_CASE`, `DOT_PREFIX` | How version properties are named |
 
 ### Property Naming Examples

--- a/website/content/docs/maven/cross-pom.md
+++ b/website/content/docs/maven/cross-pom.md
@@ -30,7 +30,7 @@ Move all dependency versions to the parent in one call:
 
 When a dependency is aligned to a parent POM:
 
-1. **Version resolution** - The child's version is resolved (including property lookup if `${...}`)
+1. **Version resolution** - The child's version is resolved (including property lookup if `$\{...}`)
 2. **Property migration** - If the child uses a property reference, the property definition is migrated to the parent
 3. **Managed dependency creation** - A `<dependency>` entry is created in the parent's `<dependencyManagement>`
 4. **Child version removal** - The `<version>` element is removed from the child dependency
@@ -41,9 +41,9 @@ When a dependency is aligned to a parent POM:
 | Child version | Target source | Result in parent |
 |--------------|---------------|------------------|
 | `2.0.7` (literal) | `LITERAL` | `<version>2.0.7</version>` |
-| `2.0.7` (literal) | `PROPERTY` | Property created + `<version>${slf4j-api.version}</version>` |
-| `${slf4j.version}` (property) | `PROPERTY` | Property migrated + `<version>${slf4j.version}</version>` |
-| `${slf4j.version}` (property) | `LITERAL` | `<version>2.0.7</version>` (resolved) |
+| `2.0.7` (literal) | `PROPERTY` | Property created + `<version>$\{slf4j-api.version}</version>` |
+| `$\{slf4j.version}` (property) | `PROPERTY` | Property migrated + `<version>$\{slf4j.version}</version>` |
+| `$\{slf4j.version}` (property) | `LITERAL` | `<version>2.0.7</version>` (resolved) |
 
 ## AlignOptions for Cross-POM
 

--- a/website/content/docs/maven/installation.md
+++ b/website/content/docs/maven/installation.md
@@ -88,7 +88,7 @@ When you add the Maven extension, you get access to:
 - `MavenPomElements` - Constants for Maven POM elements and attributes
 
 ### Package Structure
-```
+```text
 eu.maveniverse.domtrip.maven
 ├── PomEditor.class
 ├── PomEditor$Dependencies.class

--- a/website/content/docs/maven/overview.md
+++ b/website/content/docs/maven/overview.md
@@ -42,8 +42,8 @@ Automatically adds appropriate blank lines between element groups to maintain re
 ### Sub-Object APIs
 Domain-specific APIs accessed via the PomEditor:
 
-| API | Access | Operations |
-|-----|--------|------------|
+| API | Access | Purpose |
+|-----|--------|---------|
 | **Dependencies** | `editor.dependencies()` | CRUD, exclusions, alignment, convention detection, profile scoping |
 | **Plugins** | `editor.plugins()` | CRUD, pluginManagement |
 | **Properties** | `editor.properties()` | CRUD |

--- a/website/templates/layouts/index.html
+++ b/website/templates/layouts/index.html
@@ -36,6 +36,7 @@
                     <li><a href="{site.url}javadoc/">Javadoc</a></li>
                     <li><a href="{site.url}examples/">Examples</a></li>
                 </ul>
+                <a href="https://github.com/maveniverse/domtrip" class="navbar-github">GitHub</a>
                 </div>
             </nav>
         </header>


### PR DESCRIPTION
## Summary

- Escape `${...}` Maven property references with `\{` in alignment.md and cross-pom.md so Qute does not interpret them as template expressions (fixes broken page rendering)
- Add the GitHub navbar link to the index layout to match the page layout

Fixes the CI failures from #186.

## Test plan

- [x] Verified locally with `quarkus:run` — alignment and cross-pom pages render correctly
- [x] No new Qute template errors
- [ ] CI website build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Maven convention documentation with corrected property reference examples.
  * Improved code block formatting in installation guide.

* **UI Improvements**
  * Added GitHub repository link to the top navigation bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->