### PR TITLE
perf: optimize parser for 2-3x faster XML parsing

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,10 +28,46 @@
       <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.37</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.37</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <!-- Enable annotation processing for test compilation (parent sets proc=none) -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-testCompile</id>
+            <configuration>
+              <proc>full</proc>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Exclude JMH benchmarks and generated classes from normal test runs -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/*Benchmark*</exclude>
+            <exclude>**/jmh_generated/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <!-- Javadoc generation -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
@@ -153,20 +153,48 @@ public class Attribute {
     }
 
     /**
-     * Escapes special characters in attribute values with specific quote character
+     * Escapes special characters in attribute values with specific quote character.
+     * Uses a fast-path check to avoid allocation when no special chars are present.
      */
     private String escapeAttributeValue(String value, char quoteChar) {
         if (value == null) return "";
-        String result = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
 
-        // Only escape the quote character that's being used
-        if (quoteChar == '"') {
-            result = result.replace("\"", "&quot;");
-        } else if (quoteChar == '\'') {
-            result = result.replace("'", "&apos;");
+        // Fast path: scan for any character that needs escaping
+        int len = value.length();
+        int firstSpecial = -1;
+        for (int i = 0; i < len; i++) {
+            char c = value.charAt(i);
+            if (c == '&' || c == '<' || c == '>' || c == quoteChar) {
+                firstSpecial = i;
+                break;
+            }
+        }
+        if (firstSpecial < 0) {
+            return value; // No escaping needed — common case
         }
 
-        return result;
+        // Single-pass escape from the first special character
+        StringBuilder sb = new StringBuilder(len + 16);
+        if (firstSpecial > 0) {
+            sb.append(value, 0, firstSpecial);
+        }
+        for (int i = firstSpecial; i < len; i++) {
+            char c = value.charAt(i);
+            if (c == '&') {
+                sb.append("&amp;");
+            } else if (c == '<') {
+                sb.append("&lt;");
+            } else if (c == '>') {
+                sb.append("&gt;");
+            } else if (c == '"' && quoteChar == '"') {
+                sb.append("&quot;");
+            } else if (c == '\'' && quoteChar == '\'') {
+                sb.append("&apos;");
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     /**

--- a/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
@@ -143,11 +143,11 @@ public class Attribute {
     }
 
     /**
-         * Provides the attribute value to use during XML serialization, preferring the original raw text when requested.
-         *
-         * @param useRaw if true, return the preserved raw attribute text when present; otherwise produce an escaped form
-         * @return `rawValue` if `useRaw` is true and a raw value exists, otherwise the escaped form of `value` using the active quote character
-         */
+     * Provides the attribute value to use during XML serialization, preferring the original raw text when requested.
+     *
+     * @param useRaw if true, return the preserved raw attribute text when present; otherwise produce an escaped form
+     * @return `rawValue` if `useRaw` is true and a raw value exists, otherwise the escaped form of `value` using the active quote character
+     */
     public String getSerializationValue(boolean useRaw) {
         if (useRaw && rawValue != null) {
             return rawValue;
@@ -166,41 +166,49 @@ public class Attribute {
         if (value == null) return "";
 
         // Fast path: scan for any character that needs escaping
-        int len = value.length();
-        int firstSpecial = -1;
-        for (int i = 0; i < len; i++) {
-            char c = value.charAt(i);
-            if (c == '&' || c == '<' || c == '>' || c == quoteChar) {
-                firstSpecial = i;
-                break;
-            }
-        }
+        int firstSpecial = indexOfSpecialChar(value, quoteChar);
         if (firstSpecial < 0) {
             return value; // No escaping needed — common case
         }
 
         // Single-pass escape from the first special character
-        StringBuilder sb = new StringBuilder(len + 16);
-        if (firstSpecial > 0) {
-            sb.append(value, 0, firstSpecial);
-        }
-        for (int i = firstSpecial; i < len; i++) {
+        return escapeFrom(value, firstSpecial, quoteChar);
+    }
+
+    private static int indexOfSpecialChar(String value, char quoteChar) {
+        for (int i = 0, len = value.length(); i < len; i++) {
             char c = value.charAt(i);
-            if (c == '&') {
-                sb.append("&amp;");
-            } else if (c == '<') {
-                sb.append("&lt;");
-            } else if (c == '>') {
-                sb.append("&gt;");
-            } else if (c == '"' && quoteChar == '"') {
-                sb.append("&quot;");
-            } else if (c == '\'' && quoteChar == '\'') {
-                sb.append("&apos;");
-            } else {
-                sb.append(c);
+            if (c == '&' || c == '<' || c == '>' || c == quoteChar) {
+                return i;
             }
         }
+        return -1;
+    }
+
+    private static String escapeFrom(String value, int from, char quoteChar) {
+        int len = value.length();
+        StringBuilder sb = new StringBuilder(len + 16);
+        if (from > 0) {
+            sb.append(value, 0, from);
+        }
+        for (int i = from; i < len; i++) {
+            appendEscaped(sb, value.charAt(i), quoteChar);
+        }
         return sb.toString();
+    }
+
+    private static void appendEscaped(StringBuilder sb, char c, char quoteChar) {
+        if (c == '&') {
+            sb.append("&amp;");
+        } else if (c == '<') {
+            sb.append("&lt;");
+        } else if (c == '>') {
+            sb.append("&gt;");
+        } else if (c == quoteChar) {
+            sb.append(quoteChar == '"' ? "&quot;" : "&apos;");
+        } else {
+            sb.append(c);
+        }
     }
 
     /**

--- a/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
@@ -143,8 +143,11 @@ public class Attribute {
     }
 
     /**
-     * Gets the value to use for serialization (raw if available, otherwise escaped)
-     */
+         * Provides the attribute value to use during XML serialization, preferring the original raw text when requested.
+         *
+         * @param useRaw if true, return the preserved raw attribute text when present; otherwise produce an escaped form
+         * @return `rawValue` if `useRaw` is true and a raw value exists, otherwise the escaped form of `value` using the active quote character
+         */
     public String getSerializationValue(boolean useRaw) {
         if (useRaw && rawValue != null) {
             return rawValue;
@@ -153,8 +156,11 @@ public class Attribute {
     }
 
     /**
-     * Escapes special characters in attribute values with specific quote character.
-     * Uses a fast-path check to avoid allocation when no special chars are present.
+     * Produce an XML-safe attribute value by escaping '&', '<', '>' and the active quote character.
+     *
+     * @param value the attribute value to escape; if {@code null} it is treated as empty
+     * @param quoteChar the quote character used to delimit the attribute (only this quote is escaped)
+     * @return the escaped attribute value; returns the original string unchanged if no escaping was required
      */
     private String escapeAttributeValue(String value, char quoteChar) {
         if (value == null) return "";

--- a/core/src/main/java/eu/maveniverse/domtrip/Element.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Element.java
@@ -94,8 +94,17 @@ public class Element extends ContainerNode {
     private String closeTagWhitespace; // Whitespace within the closing tag
     private String innerPrecedingWhitespace; // Whitespace immediately before the closing tag
     private boolean selfClosing;
-    private String originalOpenTag; // Original opening tag for reference
-    private String originalCloseTag; // Original closing tag for reference
+
+    // Source-backed original tag storage — avoids substring allocation during parsing.
+    // When tagSource is non-null and indices are >= 0, the original tag text is a slice
+    // of the source XML. The materialized String fields are lazily populated on first access.
+    private String tagSource; // Reference to source XML string (shared for open + close tags)
+    private int openTagStart = -1; // Start index into tagSource (-1 = not source-backed)
+    private int openTagEnd = -1;
+    private int closeTagStart = -1;
+    private int closeTagEnd = -1;
+    private String originalOpenTag; // Materialized string (from public API or lazily from source)
+    private String originalCloseTag;
 
     /**
      * Creates a new XML element with the specified name.
@@ -118,8 +127,6 @@ public class Element extends ContainerNode {
         this.closeTagWhitespace = "";
         this.innerPrecedingWhitespace = "";
         this.selfClosing = false;
-        this.originalOpenTag = "";
-        this.originalCloseTag = "";
     }
 
     /**
@@ -141,6 +148,11 @@ public class Element extends ContainerNode {
         this.closeTagWhitespace = original.closeTagWhitespace;
         this.innerPrecedingWhitespace = original.innerPrecedingWhitespace;
         this.selfClosing = original.selfClosing;
+        this.tagSource = original.tagSource;
+        this.openTagStart = original.openTagStart;
+        this.openTagEnd = original.openTagEnd;
+        this.closeTagStart = original.closeTagStart;
+        this.closeTagEnd = original.closeTagEnd;
         this.originalOpenTag = original.originalOpenTag;
         this.originalCloseTag = original.originalCloseTag;
 
@@ -565,9 +577,16 @@ public class Element extends ContainerNode {
     /**
      * Gets the original opening tag as it appeared in the source XML.
      *
-     * @return the original opening tag string
+     * @return the original opening tag string, or empty string if not available
      */
     public String originalOpenTag() {
+        if (originalOpenTag == null) {
+            if (openTagStart >= 0) {
+                originalOpenTag = tagSource.substring(openTagStart, openTagEnd);
+            } else {
+                return "";
+            }
+        }
         return originalOpenTag;
     }
 
@@ -579,15 +598,34 @@ public class Element extends ContainerNode {
      */
     public Element originalOpenTag(String originalOpenTag) {
         this.originalOpenTag = originalOpenTag != null ? originalOpenTag : "";
+        this.openTagStart = -1; // No longer source-backed
         return this;
+    }
+
+    /**
+     * Sets the original opening tag as a source-backed slice (avoids substring allocation).
+     * For use during parsing only.
+     */
+    void originalOpenTagInternal(String source, int start, int end) {
+        this.tagSource = source;
+        this.openTagStart = start;
+        this.openTagEnd = end;
+        this.originalOpenTag = null; // Lazily materialized
     }
 
     /**
      * Gets the original closing tag as it appeared in the source XML.
      *
-     * @return the original closing tag string
+     * @return the original closing tag string, or empty string if not available
      */
     public String originalCloseTag() {
+        if (originalCloseTag == null) {
+            if (closeTagStart >= 0) {
+                originalCloseTag = tagSource.substring(closeTagStart, closeTagEnd);
+            } else {
+                return "";
+            }
+        }
         return originalCloseTag;
     }
 
@@ -599,15 +637,63 @@ public class Element extends ContainerNode {
      */
     public Element originalCloseTag(String originalCloseTag) {
         this.originalCloseTag = originalCloseTag != null ? originalCloseTag : "";
+        this.closeTagStart = -1; // No longer source-backed
         return this;
+    }
+
+    /**
+     * Sets the original closing tag as a source-backed slice (avoids substring allocation).
+     * For use during parsing only.
+     */
+    void originalCloseTagInternal(String source, int start, int end) {
+        this.tagSource = source; // Same source reference as open tag
+        this.closeTagStart = start;
+        this.closeTagEnd = end;
+        this.originalCloseTag = null; // Lazily materialized
     }
 
     @Override
     public void toXml(StringBuilder sb) {
-        if (!isModified() && !originalOpenTag.isEmpty()) {
+        if (!isModified() && hasOriginalOpenTag()) {
             toXmlPreserved(sb);
         } else {
             toXmlFromScratch(sb);
+        }
+    }
+
+    /**
+     * Checks if an original open tag is available (either source-backed or materialized).
+     */
+    private boolean hasOriginalOpenTag() {
+        return openTagStart >= 0 || (originalOpenTag != null && !originalOpenTag.isEmpty());
+    }
+
+    /**
+     * Checks if an original close tag is available (either source-backed or materialized).
+     */
+    private boolean hasOriginalCloseTag() {
+        return closeTagStart >= 0 || (originalCloseTag != null && !originalCloseTag.isEmpty());
+    }
+
+    /**
+     * Appends the original open tag directly from source when possible, avoiding String creation.
+     */
+    private void appendOriginalOpenTag(StringBuilder sb) {
+        if (originalOpenTag == null && openTagStart >= 0) {
+            sb.append(tagSource, openTagStart, openTagEnd);
+        } else {
+            sb.append(originalOpenTag());
+        }
+    }
+
+    /**
+     * Appends the original close tag directly from source when possible, avoiding String creation.
+     */
+    private void appendOriginalCloseTag(StringBuilder sb) {
+        if (originalCloseTag == null && closeTagStart >= 0) {
+            sb.append(tagSource, closeTagStart, closeTagEnd);
+        } else {
+            sb.append(originalCloseTag());
         }
     }
 
@@ -618,11 +704,11 @@ public class Element extends ContainerNode {
         sb.append(precedingWhitespace);
 
         if (selfClosing) {
-            sb.append(originalOpenTag);
+            appendOriginalOpenTag(sb);
             return;
         }
 
-        sb.append(originalOpenTag);
+        appendOriginalOpenTag(sb);
 
         appendChildrenAndCloseTag(sb);
     }
@@ -656,8 +742,8 @@ public class Element extends ContainerNode {
         appendChildren(sb);
         sb.append(innerPrecedingWhitespace);
 
-        if (!originalCloseTag.isEmpty()) {
-            sb.append(originalCloseTag);
+        if (hasOriginalCloseTag()) {
+            appendOriginalCloseTag(sb);
         } else {
             sb.append("</").append(name).append(">");
         }

--- a/core/src/main/java/eu/maveniverse/domtrip/Element.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Element.java
@@ -107,14 +107,13 @@ public class Element extends ContainerNode {
     private String originalCloseTag;
 
     /**
-     * Creates a new XML element with the specified name.
+     * Create a new Element with the given tag name.
      *
-     * <p>Initializes the element with an empty attribute map, no whitespace,
-     * and sets it as a non-self-closing element. The attribute order is
-     * preserved using a LinkedHashMap.</p>
+     * <p>The element is initialized with an empty, order-preserving attribute map,
+     * default (empty) whitespace/formatting fields, and is not self-closing.</p>
      *
-     * @param name the element name (tag name)
-     * @throws DomTripException if name is null or empty
+     * @param name the element's tag name; leading/trailing whitespace is trimmed
+     * @throws DomTripException if {@code name} is null or blank
      */
     public Element(String name) throws DomTripException {
         super();
@@ -130,10 +129,15 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Private copy constructor for cloning.
-     *
-     * @param original the element to copy from
-     */
+         * Creates a deep copy of the given element.
+         *
+         * The new element contains deep-copied attribute objects and deep-copied child nodes,
+         * preserves whitespace, self-closing flag, and original-tag source/index metadata
+         * (or materialized original tag strings) from the source element.
+         * The clone does not copy the parent reference or the modified state.
+         *
+         * @param original the element to copy from
+         */
     private Element(Element original) {
         super(); // Initialize ContainerNode with empty nodes list
         this.name = original.name;
@@ -575,10 +579,13 @@ public class Element extends ContainerNode {
     // Original tag preservation
 
     /**
-     * Gets the original opening tag as it appeared in the source XML.
-     *
-     * @return the original opening tag string, or empty string if not available
-     */
+         * Provide the original open tag exactly as it appeared in the source, or an empty string if none is available.
+         *
+         * If the element was parsed from a source buffer and the original open-tag slice is available,
+         * the tag is materialized from that source on first access.
+         *
+         * @return the original opening tag string, or empty string if not available
+         */
     public String originalOpenTag() {
         if (originalOpenTag == null) {
             if (openTagStart >= 0) {
@@ -591,9 +598,9 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Sets the original opening tag for formatting preservation.
+     * Set the materialized original open tag and disable source-backed tag slicing.
      *
-     * @param originalOpenTag the original opening tag string
+     * @param originalOpenTag the original opening tag; null is treated as an empty string
      * @return this element for method chaining
      */
     public Element originalOpenTag(String originalOpenTag) {
@@ -603,8 +610,11 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Sets the original opening tag as a source-backed slice (avoids substring allocation).
-     * For use during parsing only.
+     * Record a source-backed slice for the element's original open tag for lazy materialization; intended for parser-only use.
+     *
+     * @param source the full source string containing the tag
+     * @param start  the inclusive start index of the open-tag slice within {@code source}
+     * @param end    the exclusive end index of the open-tag slice within {@code source}
      */
     void originalOpenTagInternal(String source, int start, int end) {
         this.tagSource = source;
@@ -630,9 +640,12 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Sets the original closing tag for formatting preservation.
+     * Set the materialized original closing tag and disable source-backed close-tag slicing.
      *
-     * @param originalCloseTag the original closing tag string
+     * If `originalCloseTag` is null, an empty string is stored. Calling this method clears any
+     * source-backed close-tag indices so future preserved serialization will use the provided string.
+     *
+     * @param originalCloseTag the original closing tag string (null is stored as an empty string)
      * @return this element for method chaining
      */
     public Element originalCloseTag(String originalCloseTag) {
@@ -642,9 +655,15 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Sets the original closing tag as a source-backed slice (avoids substring allocation).
-     * For use during parsing only.
-     */
+         * Register a source-backed slice that represents the element's original closing tag (for parsing use only).
+         *
+         * The actual tag string is not allocated now; it will be lazily materialized from {@code source} using the
+         * provided indices when needed.
+         *
+         * @param source the shared source string containing the closing tag
+         * @param start  the inclusive start index of the closing-tag slice in {@code source}
+         * @param end    the exclusive end index of the closing-tag slice in {@code source}
+         */
     void originalCloseTagInternal(String source, int start, int end) {
         this.tagSource = source; // Same source reference as open tag
         this.closeTagStart = start;
@@ -652,6 +671,15 @@ public class Element extends ContainerNode {
         this.originalCloseTag = null; // Lazily materialized
     }
 
+    /**
+     * Serialize this element into XML and append the result to the supplied StringBuilder.
+     *
+     * If the element has not been modified and an original open tag is available, the original
+     * tag formatting is preserved; otherwise the element is serialized from scratch using the
+     * element's current state.
+     *
+     * @param sb the StringBuilder to append the XML representation to
+     */
     @Override
     public void toXml(StringBuilder sb) {
         if (!isModified() && hasOriginalOpenTag()) {
@@ -662,21 +690,27 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Checks if an original open tag is available (either source-backed or materialized).
-     */
+         * Determine whether an original open tag is available.
+         *
+         * @return `true` if a source-backed or materialized original open tag is available, `false` otherwise.
+         */
     private boolean hasOriginalOpenTag() {
         return openTagStart >= 0 || (originalOpenTag != null && !originalOpenTag.isEmpty());
     }
 
     /**
-     * Checks if an original close tag is available (either source-backed or materialized).
-     */
+         * Determine whether a preserved original close tag exists for this element.
+         *
+         * @return `true` if a source-backed close-tag slice is present or a materialized close-tag string is non-empty, `false` otherwise.
+         */
     private boolean hasOriginalCloseTag() {
         return closeTagStart >= 0 || (originalCloseTag != null && !originalCloseTag.isEmpty());
     }
 
     /**
-     * Appends the original open tag directly from source when possible, avoiding String creation.
+     * Appends the element's preserved original open tag to the provided StringBuilder, using the source-backed slice when available.
+     *
+     * @param sb the StringBuilder to append to
      */
     private void appendOriginalOpenTag(StringBuilder sb) {
         if (originalOpenTag == null && openTagStart >= 0) {
@@ -687,8 +721,13 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Appends the original close tag directly from source when possible, avoiding String creation.
-     */
+         * Appends the element's preserved original close tag to the provided StringBuilder.
+         *
+         * If a source-backed slice of the original close tag is available, that slice is appended;
+         * otherwise the materialized original close tag string is appended.
+         *
+         * @param sb the StringBuilder to append the close tag to
+         */
     private void appendOriginalCloseTag(StringBuilder sb) {
         if (originalCloseTag == null && closeTagStart >= 0) {
             sb.append(tagSource, closeTagStart, closeTagEnd);
@@ -698,7 +737,9 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Serializes using preserved original formatting.
+     * Serialize this element into the given StringBuilder using preserved original tags and formatting.
+     *
+     * @param sb the StringBuilder to append the serialized element to
      */
     private void toXmlPreserved(StringBuilder sb) {
         sb.append(precedingWhitespace);
@@ -736,8 +777,11 @@ public class Element extends ContainerNode {
     }
 
     /**
-     * Appends children and closing tag for preserved formatting mode.
-     */
+         * Append this element's children, then its inner preceding whitespace, and finally the closing tag to the provided StringBuilder,
+         * using the preserved original close-tag text when available.
+         *
+         * @param sb the StringBuilder to append XML content to
+         */
     private void appendChildrenAndCloseTag(StringBuilder sb) {
         appendChildren(sb);
         sb.append(innerPrecedingWhitespace);

--- a/core/src/main/java/eu/maveniverse/domtrip/Element.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Element.java
@@ -152,13 +152,14 @@ public class Element extends ContainerNode {
         this.closeTagWhitespace = original.closeTagWhitespace;
         this.innerPrecedingWhitespace = original.innerPrecedingWhitespace;
         this.selfClosing = original.selfClosing;
-        this.tagSource = original.tagSource;
-        this.openTagStart = original.openTagStart;
-        this.openTagEnd = original.openTagEnd;
-        this.closeTagStart = original.closeTagStart;
-        this.closeTagEnd = original.closeTagEnd;
-        this.originalOpenTag = original.originalOpenTag;
-        this.originalCloseTag = original.originalCloseTag;
+        // Materialize original tags to avoid pinning the entire source buffer
+        this.originalOpenTag = original.originalOpenTag();
+        this.originalCloseTag = original.originalCloseTag();
+        this.tagSource = null;
+        this.openTagStart = -1;
+        this.openTagEnd = -1;
+        this.closeTagStart = -1;
+        this.closeTagEnd = -1;
 
         // Copy inherited Node properties
         this.precedingWhitespace = original.precedingWhitespace;

--- a/core/src/main/java/eu/maveniverse/domtrip/Element.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Element.java
@@ -129,15 +129,15 @@ public class Element extends ContainerNode {
     }
 
     /**
-         * Creates a deep copy of the given element.
-         *
-         * The new element contains deep-copied attribute objects and deep-copied child nodes,
-         * preserves whitespace, self-closing flag, and original-tag source/index metadata
-         * (or materialized original tag strings) from the source element.
-         * The clone does not copy the parent reference or the modified state.
-         *
-         * @param original the element to copy from
-         */
+     * Creates a deep copy of the given element.
+     *
+     * The new element contains deep-copied attribute objects and deep-copied child nodes,
+     * preserves whitespace, self-closing flag, and original-tag source/index metadata
+     * (or materialized original tag strings) from the source element.
+     * The clone does not copy the parent reference or the modified state.
+     *
+     * @param original the element to copy from
+     */
     private Element(Element original) {
         super(); // Initialize ContainerNode with empty nodes list
         this.name = original.name;
@@ -579,13 +579,13 @@ public class Element extends ContainerNode {
     // Original tag preservation
 
     /**
-         * Provide the original open tag exactly as it appeared in the source, or an empty string if none is available.
-         *
-         * If the element was parsed from a source buffer and the original open-tag slice is available,
-         * the tag is materialized from that source on first access.
-         *
-         * @return the original opening tag string, or empty string if not available
-         */
+     * Provide the original open tag exactly as it appeared in the source, or an empty string if none is available.
+     *
+     * If the element was parsed from a source buffer and the original open-tag slice is available,
+     * the tag is materialized from that source on first access.
+     *
+     * @return the original opening tag string, or empty string if not available
+     */
     public String originalOpenTag() {
         if (originalOpenTag == null) {
             if (openTagStart >= 0) {
@@ -655,15 +655,15 @@ public class Element extends ContainerNode {
     }
 
     /**
-         * Register a source-backed slice that represents the element's original closing tag (for parsing use only).
-         *
-         * The actual tag string is not allocated now; it will be lazily materialized from {@code source} using the
-         * provided indices when needed.
-         *
-         * @param source the shared source string containing the closing tag
-         * @param start  the inclusive start index of the closing-tag slice in {@code source}
-         * @param end    the exclusive end index of the closing-tag slice in {@code source}
-         */
+     * Register a source-backed slice that represents the element's original closing tag (for parsing use only).
+     *
+     * The actual tag string is not allocated now; it will be lazily materialized from {@code source} using the
+     * provided indices when needed.
+     *
+     * @param source the shared source string containing the closing tag
+     * @param start  the inclusive start index of the closing-tag slice in {@code source}
+     * @param end    the exclusive end index of the closing-tag slice in {@code source}
+     */
     void originalCloseTagInternal(String source, int start, int end) {
         this.tagSource = source; // Same source reference as open tag
         this.closeTagStart = start;
@@ -690,19 +690,19 @@ public class Element extends ContainerNode {
     }
 
     /**
-         * Determine whether an original open tag is available.
-         *
-         * @return `true` if a source-backed or materialized original open tag is available, `false` otherwise.
-         */
+     * Determine whether an original open tag is available.
+     *
+     * @return `true` if a source-backed or materialized original open tag is available, `false` otherwise.
+     */
     private boolean hasOriginalOpenTag() {
         return openTagStart >= 0 || (originalOpenTag != null && !originalOpenTag.isEmpty());
     }
 
     /**
-         * Determine whether a preserved original close tag exists for this element.
-         *
-         * @return `true` if a source-backed close-tag slice is present or a materialized close-tag string is non-empty, `false` otherwise.
-         */
+     * Determine whether a preserved original close tag exists for this element.
+     *
+     * @return `true` if a source-backed close-tag slice is present or a materialized close-tag string is non-empty, `false` otherwise.
+     */
     private boolean hasOriginalCloseTag() {
         return closeTagStart >= 0 || (originalCloseTag != null && !originalCloseTag.isEmpty());
     }
@@ -721,13 +721,13 @@ public class Element extends ContainerNode {
     }
 
     /**
-         * Appends the element's preserved original close tag to the provided StringBuilder.
-         *
-         * If a source-backed slice of the original close tag is available, that slice is appended;
-         * otherwise the materialized original close tag string is appended.
-         *
-         * @param sb the StringBuilder to append the close tag to
-         */
+     * Appends the element's preserved original close tag to the provided StringBuilder.
+     *
+     * If a source-backed slice of the original close tag is available, that slice is appended;
+     * otherwise the materialized original close tag string is appended.
+     *
+     * @param sb the StringBuilder to append the close tag to
+     */
     private void appendOriginalCloseTag(StringBuilder sb) {
         if (originalCloseTag == null && closeTagStart >= 0) {
             sb.append(tagSource, closeTagStart, closeTagEnd);
@@ -777,11 +777,11 @@ public class Element extends ContainerNode {
     }
 
     /**
-         * Append this element's children, then its inner preceding whitespace, and finally the closing tag to the provided StringBuilder,
-         * using the preserved original close-tag text when available.
-         *
-         * @param sb the StringBuilder to append XML content to
-         */
+     * Append this element's children, then its inner preceding whitespace, and finally the closing tag to the provided StringBuilder,
+     * using the preserved original close-tag text when available.
+     *
+     * @param sb the StringBuilder to append XML content to
+     */
     private void appendChildrenAndCloseTag(StringBuilder sb) {
         appendChildren(sb);
         sb.append(innerPrecedingWhitespace);

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -325,18 +325,27 @@ public class Parser {
     }
 
     /**
-     * Determines whether the provided StringBuilder contains only Unicode whitespace characters.
+     * Determines whether the provided StringBuilder contains only XML whitespace characters
+     * (space, tab, carriage return, line feed) as defined by the XML 1.0 specification.
      *
      * @param sb the StringBuilder to inspect
-     * @return `true` if every character in `sb` is whitespace, `false` otherwise
+     * @return {@code true} if every character in {@code sb} is XML whitespace, {@code false} otherwise
      */
     private static boolean isWhitespaceOnlyBuf(StringBuilder sb) {
         for (int i = 0, len = sb.length(); i < len; i++) {
-            if (!Character.isWhitespace(sb.charAt(i))) {
+            if (!isXmlWhitespace(sb.charAt(i))) {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Checks whether a character is XML whitespace per the XML 1.0 specification:
+     * S ::= (#x20 | #x9 | #xD | #xA)+
+     */
+    private static boolean isXmlWhitespace(char c) {
+        return c == ' ' || c == '\t' || c == '\r' || c == '\n';
     }
 
     /**
@@ -844,17 +853,18 @@ public class Parser {
     }
 
     /**
-     * Determine whether a string consists only of whitespace characters.
+     * Determine whether a string consists only of XML whitespace characters
+     * (space, tab, carriage return, line feed) as defined by the XML 1.0 specification.
      *
      * @param content the string to test, may be null
-     * @return `true` if {@code content} is non-null and every character is whitespace, `false` otherwise
+     * @return {@code true} if {@code content} is non-null and every character is XML whitespace, {@code false} otherwise
      */
     private static boolean isWhitespaceOnly(String content) {
         if (content == null) {
             return false;
         }
         for (int i = 0, len = content.length(); i < len; i++) {
-            if (!Character.isWhitespace(content.charAt(i))) {
+            if (!isXmlWhitespace(content.charAt(i))) {
                 return false;
             }
         }

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -648,7 +648,7 @@ public class Parser {
         // Parse element name using substring
         int nameStart = position;
         while (position < length
-                && !Character.isWhitespace(xml.charAt(position))
+                && !isXmlWhitespace(xml.charAt(position))
                 && xml.charAt(position) != '>'
                 && xml.charAt(position) != '/') {
             position++;
@@ -679,7 +679,7 @@ public class Parser {
                 && xml.charAt(position) != '>'
                 && !(xml.charAt(position) == '/' && position + 1 < length && xml.charAt(position + 1) == '>')) {
 
-            if (Character.isWhitespace(xml.charAt(position))) {
+            if (isXmlWhitespace(xml.charAt(position))) {
                 position++;
             } else {
                 String attrWs = wsStart < position ? xml.substring(wsStart, position) : "";
@@ -736,19 +736,19 @@ public class Parser {
      */
     private String parseAttributeName() {
         int nameStart = position;
-        while (position < length && xml.charAt(position) != '=' && !Character.isWhitespace(xml.charAt(position))) {
+        while (position < length && xml.charAt(position) != '=' && !isXmlWhitespace(xml.charAt(position))) {
             position++;
         }
         return xml.substring(nameStart, position);
     }
 
     /**
-     * Advances the parser cursor past any consecutive Unicode whitespace characters.
+     * Advances the parser cursor past any consecutive XML whitespace characters.
      *
      * Stops when the cursor reaches the first non-whitespace character or the end of input.
      */
     private void skipWhitespace() {
-        while (position < length && Character.isWhitespace(xml.charAt(position))) {
+        while (position < length && isXmlWhitespace(xml.charAt(position))) {
             position++;
         }
     }
@@ -757,7 +757,7 @@ public class Parser {
         // Skip '=' and any whitespace after it
         do {
             position++;
-        } while (position < length && Character.isWhitespace(xml.charAt(position)));
+        } while (position < length && isXmlWhitespace(xml.charAt(position)));
     }
 
     /**
@@ -807,20 +807,20 @@ public class Parser {
 
         // Capture whitespace before the element name
         int wsStart = position;
-        while (position < length && Character.isWhitespace(xml.charAt(position))) {
+        while (position < length && isXmlWhitespace(xml.charAt(position))) {
             position++;
         }
 
         // Parse tag name using substring
         int nameStart = position;
-        while (position < length && xml.charAt(position) != '>' && !Character.isWhitespace(xml.charAt(position))) {
+        while (position < length && xml.charAt(position) != '>' && !isXmlWhitespace(xml.charAt(position))) {
             position++;
         }
 
         String closingName = xml.substring(nameStart, position);
 
         // Skip any trailing whitespace after the element name (but don't capture it)
-        while (position < length && Character.isWhitespace(xml.charAt(position))) {
+        while (position < length && isXmlWhitespace(xml.charAt(position))) {
             position++;
         }
 

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -265,15 +265,17 @@ public class Parser {
         StringBuilder pendingWhitespace = new StringBuilder();
 
         while (position < length) {
-            char ch = xml.charAt(position);
-
-            if (ch == '<') {
+            if (xml.charAt(position) == '<') {
                 flushPrecedingText(precedingWhitespace, pendingWhitespace, nodeStack);
                 parseTagStart(document, nodeStack, pendingWhitespace);
             } else {
-                // Collect text content and whitespace
-                precedingWhitespace.append(ch);
+                // Collect text content and whitespace in bulk using substring
+                int textStart = position;
                 position++;
+                while (position < length && xml.charAt(position) != '<') {
+                    position++;
+                }
+                precedingWhitespace.append(xml, textStart, position);
             }
         }
 
@@ -308,18 +310,35 @@ public class Parser {
             return;
         }
 
+        // Fast path: check if raw text is whitespace-only before unescaping.
+        // Between elements, whitespace never contains entities, so this avoids
+        // both the unescape and the whitespace-check on decoded text.
+        if (isWhitespaceOnlyBuf(precedingWhitespace)) {
+            pendingWhitespace.append(precedingWhitespace);
+            precedingWhitespace.setLength(0);
+            return;
+        }
+
         String rawText = precedingWhitespace.toString();
         String decodedText = Text.unescapeTextContent(rawText);
 
-        if (isWhitespaceOnly(decodedText)) {
-            pendingWhitespace.append(decodedText);
-        } else {
-            Text textNode = new Text(decodedText, rawText);
-            applyPendingWhitespace(textNode, pendingWhitespace);
-            ContainerNode current = (ContainerNode) nodeStack.peek();
-            current.addChildInternal(textNode);
-        }
+        Text textNode = new Text(decodedText, rawText);
+        applyPendingWhitespace(textNode, pendingWhitespace);
+        ContainerNode current = (ContainerNode) nodeStack.peek();
+        current.addChildInternal(textNode);
         precedingWhitespace.setLength(0);
+    }
+
+    /**
+     * Checks if a StringBuilder contains only whitespace, avoiding toString() allocation.
+     */
+    private static boolean isWhitespaceOnlyBuf(StringBuilder sb) {
+        for (int i = 0, len = sb.length(); i < len; i++) {
+            if (!Character.isWhitespace(sb.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -349,15 +368,16 @@ public class Parser {
      */
     private void parseDeclarationOrSpecial(Document document, Deque<Node> nodeStack, StringBuilder pendingWhitespace)
             throws DomTripException {
-        if (position + 3 < length && xml.startsWith("<!--", position)) {
+        // position is at '<', position+1 is '!'
+        if (position + 3 < length && xml.charAt(position + 2) == '-' && xml.charAt(position + 3) == '-') {
             Comment comment = parseComment();
             applyPendingWhitespace(comment, pendingWhitespace);
             ((ContainerNode) nodeStack.peek()).addChildInternal(comment);
-        } else if (position + 8 < length && xml.startsWith("<![CDATA[", position)) {
+        } else if (position + 8 < length && xml.charAt(position + 2) == '[' && xml.startsWith("<![CDATA[", position)) {
             Text cdata = parseCData();
             applyPendingWhitespace(cdata, pendingWhitespace);
             ((ContainerNode) nodeStack.peek()).addChildInternal(cdata);
-        } else if (position + 9 < length && xml.startsWith("<!DOCTYPE", position)) {
+        } else if (position + 9 < length && xml.charAt(position + 2) == 'D' && xml.startsWith("<!DOCTYPE", position)) {
             String doctype = parseDoctype();
             document.doctype(doctype);
             if (pendingWhitespace.length() > 0) {
@@ -451,14 +471,14 @@ public class Parser {
 
     private Comment parseComment() throws DomTripException {
         position += 4; // Skip "<!--"
+        int contentStart = position;
 
-        StringBuilder content = new StringBuilder();
         while (position + 2 < length) {
-            if (xml.startsWith("-->", position)) {
+            if (xml.charAt(position) == '-' && xml.charAt(position + 1) == '-' && xml.charAt(position + 2) == '>') {
+                String content = xml.substring(contentStart, position);
                 position += 3;
-                return new Comment(content.toString());
+                return new Comment(content);
             }
-            content.append(xml.charAt(position));
             position++;
         }
 
@@ -467,14 +487,14 @@ public class Parser {
 
     private Text parseCData() throws DomTripException {
         position += 9; // Skip "<![CDATA["
+        int contentStart = position;
 
-        StringBuilder content = new StringBuilder();
         while (position + 2 < length) {
-            if (xml.startsWith("]]>", position)) {
+            if (xml.charAt(position) == ']' && xml.charAt(position + 1) == ']' && xml.charAt(position + 2) == '>') {
+                String content = xml.substring(contentStart, position);
                 position += 3;
-                return new Text(content.toString(), true);
+                return new Text(content, true);
             }
-            content.append(xml.charAt(position));
             position++;
         }
 
@@ -486,7 +506,7 @@ public class Parser {
         position += 2; // Skip "<?"
 
         while (position + 1 < length) {
-            if (xml.startsWith("?>", position)) {
+            if (xml.charAt(position) == '?' && xml.charAt(position + 1) == '>') {
                 position += 2;
                 return xml.substring(start, position);
             }
@@ -570,46 +590,42 @@ public class Parser {
         int start = position;
         position++; // Skip '<'
 
-        // Parse element name
-        StringBuilder name = new StringBuilder();
+        // Parse element name using substring
+        int nameStart = position;
         while (position < length
                 && !Character.isWhitespace(xml.charAt(position))
                 && xml.charAt(position) != '>'
                 && xml.charAt(position) != '/') {
-            name.append(xml.charAt(position));
             position++;
         }
 
-        String elementName = name.toString();
-        if (elementName.isEmpty()) {
+        if (position == nameStart) {
             throw new DomTripException("Empty element name", position, xml);
         }
 
+        String elementName = xml.substring(nameStart, position);
         Element element = new Element(elementName);
 
-        // Store original opening tag for whitespace preservation
-
-        // Parse attributes and whitespace
-        StringBuilder currentWhitespace = new StringBuilder();
+        // Parse attributes and whitespace — track whitespace positions
+        // to avoid StringBuilder allocation per attribute
+        int wsStart = position;
         while (position < length
                 && xml.charAt(position) != '>'
                 && !(xml.charAt(position) == '/' && position + 1 < length && xml.charAt(position + 1) == '>')) {
 
             if (Character.isWhitespace(xml.charAt(position))) {
-                // Collect whitespace that precedes the next attribute
-                currentWhitespace.append(xml.charAt(position));
                 position++;
             } else {
-                // Parse attribute with the collected whitespace
-                parseAttribute(element, currentWhitespace.toString());
-                currentWhitespace.setLength(0); // Reset for next attribute
+                // Parse attribute with the collected whitespace (substring from tracked positions)
+                String attrWs = wsStart < position ? xml.substring(wsStart, position) : "";
+                parseAttribute(element, attrWs);
+                wsStart = position; // Reset for next attribute's whitespace
             }
         }
 
         // Capture any remaining whitespace before the closing > or />
-        // This is the openTagWhitespace
-        if (currentWhitespace.length() > 0) {
-            element.openTagWhitespaceInternal(currentWhitespace.toString());
+        if (wsStart < position) {
+            element.openTagWhitespaceInternal(xml.substring(wsStart, position));
         }
 
         // Check for self-closing tag
@@ -624,8 +640,8 @@ public class Parser {
             throw new DomTripException("Unclosed opening tag '" + elementName + "'", position, xml);
         }
 
-        // Store original tag content for formatting preservation
-        element.originalOpenTag(xml.substring(start, position));
+        // Store original tag content as source-backed slice (avoids substring allocation)
+        element.originalOpenTagInternal(xml, start, position);
         return element;
     }
 
@@ -653,12 +669,11 @@ public class Parser {
     }
 
     private String parseAttributeName() {
-        StringBuilder name = new StringBuilder();
+        int nameStart = position;
         while (position < length && xml.charAt(position) != '=' && !Character.isWhitespace(xml.charAt(position))) {
-            name.append(xml.charAt(position));
             position++;
         }
-        return name.toString();
+        return xml.substring(nameStart, position);
     }
 
     private void skipWhitespace() {
@@ -682,19 +697,19 @@ public class Parser {
         char quote = xml.charAt(position);
         position++; // Skip opening quote
 
-        StringBuilder value = new StringBuilder();
+        // Scan for closing quote using substring instead of char-by-char append
+        int valueStart = position;
         while (position < length && xml.charAt(position) != quote) {
-            value.append(xml.charAt(position));
             position++;
         }
 
-        if (position < length) {
-            position++; // Skip closing quote
-        } else {
+        if (position >= length) {
             throw new DomTripException("Unclosed attribute value", position, xml);
         }
 
-        String rawValue = value.toString();
+        String rawValue = xml.substring(valueStart, position);
+        position++; // Skip closing quote
+
         String decodedValue = Text.unescapeTextContent(rawValue);
         String actualWhitespace = precedingWhitespace.isEmpty() ? " " : precedingWhitespace;
         element.attributeInternal(name, decodedValue, quote, actualWhitespace, rawValue);
@@ -715,18 +730,18 @@ public class Parser {
         position += 2; // Skip "</"
 
         // Capture whitespace before the element name
-        StringBuilder closeTagWhitespace = new StringBuilder();
+        int wsStart = position;
         while (position < length && Character.isWhitespace(xml.charAt(position))) {
-            closeTagWhitespace.append(xml.charAt(position));
             position++;
         }
 
-        // Parse tag name
-        StringBuilder name = new StringBuilder();
+        // Parse tag name using substring
+        int nameStart = position;
         while (position < length && xml.charAt(position) != '>' && !Character.isWhitespace(xml.charAt(position))) {
-            name.append(xml.charAt(position));
             position++;
         }
+
+        String closingName = xml.substring(nameStart, position);
 
         // Skip any trailing whitespace after the element name (but don't capture it)
         while (position < length && Character.isWhitespace(xml.charAt(position))) {
@@ -734,21 +749,20 @@ public class Parser {
         }
 
         if (position >= length) {
-            throw new DomTripException("Unclosed closing tag '</" + name + ">'", position, xml);
+            throw new DomTripException("Unclosed closing tag '</" + closingName + ">'", position, xml);
         }
         position++; // Skip '>'
 
         // Pop from stack if names match
-        String closingName = name.toString();
         if (!nodeStack.isEmpty() && nodeStack.peek() instanceof Element) {
             Element element = (Element) nodeStack.peek();
             if (element.name().equals(closingName)) {
-                // Capture the original close tag for whitespace preservation (AFTER consuming all content)
-                element.originalCloseTag(xml.substring(start, position));
+                // Capture the original close tag as source-backed slice (avoids substring allocation)
+                element.originalCloseTagInternal(xml, start, position);
 
                 // Capture the close tag whitespace
-                if (closeTagWhitespace.length() > 0) {
-                    element.closeTagWhitespaceInternal(closeTagWhitespace.toString());
+                if (wsStart < nameStart) {
+                    element.closeTagWhitespaceInternal(xml.substring(wsStart, nameStart));
                 }
 
                 nodeStack.pop();
@@ -765,8 +779,16 @@ public class Parser {
     /**
      * Checks if the given content contains only whitespace characters.
      */
-    private boolean isWhitespaceOnly(String content) {
-        return content != null && content.trim().isEmpty();
+    private static boolean isWhitespaceOnly(String content) {
+        if (content == null) {
+            return false;
+        }
+        for (int i = 0, len = content.length(); i < len; i++) {
+            if (!Character.isWhitespace(content.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -302,8 +302,16 @@ public class Parser {
     }
 
     /**
-     * Flushes any accumulated text/whitespace before a tag into the appropriate nodes.
-     */
+         * Attaches accumulated raw text that appears before the next '<' to the parse tree or to pending whitespace.
+         *
+         * If the accumulated text is whitespace only, it is appended to {@code pendingWhitespace}.
+         * Otherwise a Text node is created (preserving both decoded and raw text) and added as a child of the current container node from {@code nodeStack};
+         * any {@code pendingWhitespace} is applied to that Text node before attachment.
+         *
+         * @param precedingWhitespace buffer holding raw characters read up to the next '<'
+         * @param pendingWhitespace buffer of whitespace that should be applied to the next node if the preceding content is whitespace-only or when attaching a new node
+         * @param nodeStack stack of nodes with the current container on top (document is at the bottom)
+         */
     private void flushPrecedingText(
             StringBuilder precedingWhitespace, StringBuilder pendingWhitespace, Deque<Node> nodeStack) {
         if (precedingWhitespace.length() == 0) {
@@ -330,7 +338,10 @@ public class Parser {
     }
 
     /**
-     * Checks if a StringBuilder contains only whitespace, avoiding toString() allocation.
+     * Determines whether the provided StringBuilder contains only Unicode whitespace characters.
+     *
+     * @param sb the StringBuilder to inspect
+     * @return `true` if every character in `sb` is whitespace, `false` otherwise
      */
     private static boolean isWhitespaceOnlyBuf(StringBuilder sb) {
         for (int i = 0, len = sb.length(); i < len; i++) {
@@ -364,8 +375,16 @@ public class Parser {
     }
 
     /**
-     * Parses declarations (comments, CDATA, DOCTYPE, etc.) starting with '<!'.
-     */
+         * Parses a declaration or special XML construct beginning with "<!" (comment, CDATA section,
+         * DOCTYPE, or other declaration) and attaches the resulting node or metadata to the document tree.
+         *
+         * @param document the Document being built and updated (may receive a DOCTYPE or xml-declaration data)
+         * @param nodeStack the current node stack; parsed comment/CDATA nodes are added to the container at the stack top
+         * @param pendingWhitespace buffer of whitespace that should be applied as preceding whitespace to the
+         *                         parsed node or, for DOCTYPE, recorded as doctype preceding whitespace;
+         *                         this buffer may be consumed/cleared by the method
+         * @throws DomTripException if the declaration/special construct is truncated or otherwise malformed
+         */
     private void parseDeclarationOrSpecial(Document document, Deque<Node> nodeStack, StringBuilder pendingWhitespace)
             throws DomTripException {
         // position is at '<', position+1 is '!'
@@ -469,6 +488,16 @@ public class Parser {
         }
     }
 
+    /**
+     * Parses an XML comment at the current parse position and returns a Comment node.
+     *
+     * Assumes the parser is positioned at the start of a "<!--" sequence; consumes the full comment
+     * including the opening "<!--" and the closing "-->" and advances the parser position past the
+     * closing delimiter.
+     *
+     * @return the Comment whose content is the text between "<!--" and "-->"
+     * @throws DomTripException if the comment is not closed before the end of input
+     */
     private Comment parseComment() throws DomTripException {
         position += 4; // Skip "<!--"
         int contentStart = position;
@@ -485,6 +514,12 @@ public class Parser {
         throw new DomTripException("Unclosed comment", position, xml);
     }
 
+    /**
+     * Parses a CDATA section and returns it as a Text node marked as CDATA.
+     *
+     * @return a Text node whose content is the raw CDATA section and that is marked as CDATA
+     * @throws DomTripException if the CDATA section is not closed before the end of input
+     */
     private Text parseCData() throws DomTripException {
         position += 9; // Skip "<![CDATA["
         int contentStart = position;
@@ -501,6 +536,12 @@ public class Parser {
         throw new DomTripException("Unclosed CDATA section", position, xml);
     }
 
+    /**
+     * Extracts a processing instruction starting at the current parse position and returns it including the surrounding "<?" and "?>" delimiters.
+     *
+     * @return the complete processing instruction substring (including leading "<?" and trailing "?>")
+     * @throws DomTripException if the processing instruction is not closed before the end of the input
+     */
     private String parseProcessingInstruction() throws DomTripException {
         int start = position;
         position += 2; // Skip "<?"
@@ -578,12 +619,12 @@ public class Parser {
     }
 
     /**
-     * Parses an opening element tag at the current parser position and returns the created Element.
+     * Parses an opening element tag at the current parser position.
      *
-     * The returned Element contains the element name, parsed attributes, self-closing flag, and preserved
-     * original opening-tag text/whitespace for formatting fidelity.
+     * The resulting Element preserves the element name, parsed attributes, the self-closing flag,
+     * and the original opening-tag text/whitespace for formatting fidelity.
      *
-     * @return the parsed Element corresponding to the opening tag
+     * @return the parsed Element for the opening tag
      * @throws DomTripException if the element name is empty or the opening tag is not properly closed
      */
     private Element parseOpeningTag() throws DomTripException {
@@ -646,18 +687,13 @@ public class Parser {
     }
 
     /**
-     * Parses a single attribute at the parser's current position and attaches it to the given element.
-     *
-     * The method consumes the attribute name, the `=` separator and a quoted attribute value, decodes
-     * the raw value, and calls Element.attributeInternal(...) with the attribute name, decoded value,
-     * the quote character used, the whitespace to associate with the attribute (uses `precedingWhitespace`
-     * or a single space when that is empty), and the raw attribute value.
-     *
-     * @param element the Element to which the parsed attribute will be added
-     * @param precedingWhitespace the exact whitespace string that immediately preceded this attribute in the open tag;
-     *                            if empty, a single space is used when associating whitespace with the attribute
-     * @throws DomTripException if the attribute value is not terminated with a matching quote or if a quoted value is missing
-     */
+         * Parse one attribute from the current parser position and add it to the given element.
+         *
+         * @param element the Element that will receive the parsed attribute
+         * @param precedingWhitespace the exact whitespace that immediately preceded this attribute in the open tag;
+         *                            when empty a single space is associated with the attribute
+         * @throws DomTripException if a quoted attribute value is missing or not terminated with a matching quote
+         */
     private void parseAttribute(Element element, String precedingWhitespace) throws DomTripException {
         String name = parseAttributeName();
         skipWhitespace();
@@ -668,6 +704,13 @@ public class Parser {
         }
     }
 
+    /**
+     * Parse an attribute name from the current parser position and advance the position to the first character after the name.
+     *
+     * The method does not skip leading whitespace; it reads characters until it encounters `=` or any whitespace or end of input.
+     *
+     * @return the attribute name as it appears in the source; may be empty if no name characters were present
+     */
     private String parseAttributeName() {
         int nameStart = position;
         while (position < length && xml.charAt(position) != '=' && !Character.isWhitespace(xml.charAt(position))) {
@@ -676,6 +719,11 @@ public class Parser {
         return xml.substring(nameStart, position);
     }
 
+    /**
+     * Advances the parser cursor past any consecutive Unicode whitespace characters.
+     *
+     * Stops when the cursor reaches the first non-whitespace character or the end of input.
+     */
     private void skipWhitespace() {
         while (position < length && Character.isWhitespace(xml.charAt(position))) {
             position++;
@@ -689,6 +737,14 @@ public class Parser {
         } while (position < length && Character.isWhitespace(xml.charAt(position)));
     }
 
+    /**
+     * Parses a quoted attribute value at the current parse position and adds the attribute to the given element.
+     *
+     * @param element the element to which the parsed attribute will be added
+     * @param name the attribute name
+     * @param precedingWhitespace whitespace that immediately precedes the attribute value token; when empty a single space is used
+     * @throws DomTripException if the attribute value does not start with a quote or if the closing quote is not found before end of input
+     */
     private void parseAttributeValue(Element element, String name, String precedingWhitespace) throws DomTripException {
         if (position >= length || (xml.charAt(position) != '"' && xml.charAt(position) != '\'')) {
             throw new DomTripException("Missing attribute value quote", position, xml);
@@ -716,14 +772,11 @@ public class Parser {
     }
 
     /**
-     * Parses a closing tag at the current parser position, validates it against the provided node stack,
-     * finalizes the corresponding Element (captures original close-tag text and its close-tag whitespace),
-     * removes it from the stack, and returns it.
+     * Parse the closing tag at the current position, validate it against the node stack, finalize the matching Element, and remove it from the stack.
      *
-     * @param nodeStack the stack of open nodes used to validate and pop the matching Element
-     * @return the Element that was closed by this tag
-     * @throws DomTripException if the closing tag is truncated/unterminated, does not match the top Element on the stack,
-     *                          or appears when there is no open Element to match
+     * @param nodeStack the stack of open nodes; the top Element must match the parsed closing tag and will be popped
+     * @return the Element that was closed
+     * @throws DomTripException if the closing tag is truncated, does not match the top Element, or appears with no open Element to match
      */
     private Element parseClosingTag(Deque<Node> nodeStack) throws DomTripException {
         int start = position; // Remember start position for original tag capture
@@ -777,8 +830,11 @@ public class Parser {
     }
 
     /**
-     * Checks if the given content contains only whitespace characters.
-     */
+         * Determine whether a string consists only of whitespace characters.
+         *
+         * @param content the string to test, may be null
+         * @return `true` if {@code content} is non-null and every character is whitespace, `false` otherwise
+         */
     private static boolean isWhitespaceOnly(String content) {
         if (content == null) {
             return false;

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -282,36 +282,23 @@ public class Parser {
         // Handle any remaining whitespace/text
         flushRemainingContent(document, precedingWhitespace, pendingWhitespace);
 
-        // Check for unclosed elements
-        if (nodeStack.size() > 1) {
-            Node unclosed = nodeStack.peek();
-            if (unclosed instanceof Element) {
-                throw new DomTripException("Unclosed element '<" + ((Element) unclosed).name() + ">'");
-            }
-        }
-
-        // Set the document element (first element child)
-        for (Node child : document.children) {
-            if (child instanceof Element) {
-                document.rootInternal((Element) child);
-                break;
-            }
-        }
+        checkUnclosedElements(nodeStack);
+        setDocumentRoot(document);
 
         return document;
     }
 
     /**
-         * Attaches accumulated raw text that appears before the next '<' to the parse tree or to pending whitespace.
-         *
-         * If the accumulated text is whitespace only, it is appended to {@code pendingWhitespace}.
-         * Otherwise a Text node is created (preserving both decoded and raw text) and added as a child of the current container node from {@code nodeStack};
-         * any {@code pendingWhitespace} is applied to that Text node before attachment.
-         *
-         * @param precedingWhitespace buffer holding raw characters read up to the next '<'
-         * @param pendingWhitespace buffer of whitespace that should be applied to the next node if the preceding content is whitespace-only or when attaching a new node
-         * @param nodeStack stack of nodes with the current container on top (document is at the bottom)
-         */
+     * Attaches accumulated raw text that appears before the next '<' to the parse tree or to pending whitespace.
+     *
+     * If the accumulated text is whitespace only, it is appended to {@code pendingWhitespace}.
+     * Otherwise a Text node is created (preserving both decoded and raw text) and added as a child of the current container node from {@code nodeStack};
+     * any {@code pendingWhitespace} is applied to that Text node before attachment.
+     *
+     * @param precedingWhitespace buffer holding raw characters read up to the next '<'
+     * @param pendingWhitespace buffer of whitespace that should be applied to the next node if the preceding content is whitespace-only or when attaching a new node
+     * @param nodeStack stack of nodes with the current container on top (document is at the bottom)
+     */
     private void flushPrecedingText(
             StringBuilder precedingWhitespace, StringBuilder pendingWhitespace, Deque<Node> nodeStack) {
         if (precedingWhitespace.length() == 0) {
@@ -375,16 +362,16 @@ public class Parser {
     }
 
     /**
-         * Parses a declaration or special XML construct beginning with "<!" (comment, CDATA section,
-         * DOCTYPE, or other declaration) and attaches the resulting node or metadata to the document tree.
-         *
-         * @param document the Document being built and updated (may receive a DOCTYPE or xml-declaration data)
-         * @param nodeStack the current node stack; parsed comment/CDATA nodes are added to the container at the stack top
-         * @param pendingWhitespace buffer of whitespace that should be applied as preceding whitespace to the
-         *                         parsed node or, for DOCTYPE, recorded as doctype preceding whitespace;
-         *                         this buffer may be consumed/cleared by the method
-         * @throws DomTripException if the declaration/special construct is truncated or otherwise malformed
-         */
+     * Parses a declaration or special XML construct beginning with "<!" (comment, CDATA section,
+     * DOCTYPE, or other declaration) and attaches the resulting node or metadata to the document tree.
+     *
+     * @param document the Document being built and updated (may receive a DOCTYPE or xml-declaration data)
+     * @param nodeStack the current node stack; parsed comment/CDATA nodes are added to the container at the stack top
+     * @param pendingWhitespace buffer of whitespace that should be applied as preceding whitespace to the
+     *                         parsed node or, for DOCTYPE, recorded as doctype preceding whitespace;
+     *                         this buffer may be consumed/cleared by the method
+     * @throws DomTripException if the declaration/special construct is truncated or otherwise malformed
+     */
     private void parseDeclarationOrSpecial(Document document, Deque<Node> nodeStack, StringBuilder pendingWhitespace)
             throws DomTripException {
         // position is at '<', position+1 is '!'
@@ -485,6 +472,24 @@ public class Parser {
         if (pendingWhitespace.length() > 0) {
             Text trailingWhitespace = new Text(pendingWhitespace.toString());
             document.addChildInternal(trailingWhitespace);
+        }
+    }
+
+    private void checkUnclosedElements(Deque<Node> nodeStack) {
+        if (nodeStack.size() > 1) {
+            Node unclosed = nodeStack.peek();
+            if (unclosed instanceof Element) {
+                throw new DomTripException("Unclosed element '<" + ((Element) unclosed).name() + ">'");
+            }
+        }
+    }
+
+    private void setDocumentRoot(Document document) {
+        for (Node child : document.children) {
+            if (child instanceof Element) {
+                document.rootInternal((Element) child);
+                break;
+            }
         }
     }
 
@@ -647,8 +652,19 @@ public class Parser {
         String elementName = xml.substring(nameStart, position);
         Element element = new Element(elementName);
 
-        // Parse attributes and whitespace — track whitespace positions
-        // to avoid StringBuilder allocation per attribute
+        parseAttributes(element);
+        parseSelfClosingAndEnd(element, elementName);
+
+        // Store original tag content as source-backed slice (avoids substring allocation)
+        element.originalOpenTagInternal(xml, start, position);
+        return element;
+    }
+
+    /**
+     * Parses all attributes and whitespace within an opening tag.
+     * Tracks whitespace positions to avoid StringBuilder allocation per attribute.
+     */
+    private void parseAttributes(Element element) throws DomTripException {
         int wsStart = position;
         while (position < length
                 && xml.charAt(position) != '>'
@@ -657,43 +673,41 @@ public class Parser {
             if (Character.isWhitespace(xml.charAt(position))) {
                 position++;
             } else {
-                // Parse attribute with the collected whitespace (substring from tracked positions)
                 String attrWs = wsStart < position ? xml.substring(wsStart, position) : "";
                 parseAttribute(element, attrWs);
-                wsStart = position; // Reset for next attribute's whitespace
+                wsStart = position;
             }
         }
 
-        // Capture any remaining whitespace before the closing > or />
         if (wsStart < position) {
             element.openTagWhitespaceInternal(xml.substring(wsStart, position));
         }
-
-        // Check for self-closing tag
-        if (position < length && xml.charAt(position) == '/') {
-            element.selfClosingInternal(true);
-            position++; // Skip '/'
-        }
-
-        if (position < length && xml.charAt(position) == '>') {
-            position++; // Skip '>'
-        } else {
-            throw new DomTripException("Unclosed opening tag '" + elementName + "'", position, xml);
-        }
-
-        // Store original tag content as source-backed slice (avoids substring allocation)
-        element.originalOpenTagInternal(xml, start, position);
-        return element;
     }
 
     /**
-         * Parse one attribute from the current parser position and add it to the given element.
-         *
-         * @param element the Element that will receive the parsed attribute
-         * @param precedingWhitespace the exact whitespace that immediately preceded this attribute in the open tag;
-         *                            when empty a single space is associated with the attribute
-         * @throws DomTripException if a quoted attribute value is missing or not terminated with a matching quote
-         */
+     * Handles the self-closing flag and closing '>' of an opening tag.
+     */
+    private void parseSelfClosingAndEnd(Element element, String elementName) throws DomTripException {
+        if (position < length && xml.charAt(position) == '/') {
+            element.selfClosingInternal(true);
+            position++;
+        }
+
+        if (position < length && xml.charAt(position) == '>') {
+            position++;
+        } else {
+            throw new DomTripException("Unclosed opening tag '" + elementName + "'", position, xml);
+        }
+    }
+
+    /**
+     * Parse one attribute from the current parser position and add it to the given element.
+     *
+     * @param element the Element that will receive the parsed attribute
+     * @param precedingWhitespace the exact whitespace that immediately preceded this attribute in the open tag;
+     *                            when empty a single space is associated with the attribute
+     * @throws DomTripException if a quoted attribute value is missing or not terminated with a matching quote
+     */
     private void parseAttribute(Element element, String precedingWhitespace) throws DomTripException {
         String name = parseAttributeName();
         skipWhitespace();
@@ -830,11 +844,11 @@ public class Parser {
     }
 
     /**
-         * Determine whether a string consists only of whitespace characters.
-         *
-         * @param content the string to test, may be null
-         * @return `true` if {@code content} is non-null and every character is whitespace, `false` otherwise
-         */
+     * Determine whether a string consists only of whitespace characters.
+     *
+     * @param content the string to test, may be null
+     * @return `true` if {@code content} is non-null and every character is whitespace, `false` otherwise
+     */
     private static boolean isWhitespaceOnly(String content) {
         if (content == null) {
             return false;

--- a/core/src/main/java/eu/maveniverse/domtrip/Text.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Text.java
@@ -312,6 +312,16 @@ public class Text extends Node {
         return !content.isEmpty() && Character.isWhitespace(content.charAt(content.length() - 1));
     }
 
+    /**
+     * Appends this text node's XML representation to the provided StringBuilder.
+     *
+     * The method writes the node's preceding whitespace, then either:
+     * - serializes the content as a CDATA section when this node is marked as CDATA, or
+     * - appends the raw, unescaped content if available and the node has not been modified,
+     *   otherwise appends the escaped text content.
+     *
+     * @param sb the StringBuilder to append XML output to
+     */
     @Override
     public void toXml(StringBuilder sb) {
         sb.append(precedingWhitespace);
@@ -329,8 +339,10 @@ public class Text extends Node {
     }
 
     /**
-     * Escapes special characters in text content.
-     * Uses a fast-path check to avoid allocation when no special chars are present.
+     * Escape XML special characters in the given text for safe inclusion in element content.
+     *
+     * @param text the input text to escape; may be {@code null} (treated as an empty string)
+     * @return the input with `&`, `<`, and `>` replaced by `&amp;`, `&lt;`, and `&gt;` respectively; empty string when input is {@code null}
      */
     static String escapeTextContent(String text) {
         if (text == null) return "";
@@ -370,7 +382,16 @@ public class Text extends Node {
     }
 
     /**
-     * Unescapes XML entities in text content, including numeric character references
+     * Convert XML character and entity references in the given text to their corresponding characters.
+     *
+     * <p>Supports named entities `&lt;`, `&gt;`, `&amp;`, `&quot;`, `&apos;` and numeric character references
+     * in decimal (`&#DDDD;`) and hexadecimal (`&#xHHHH;` / `&#XHHHH;`). Numeric references are validated
+     * against XML 1.0 allowed code point ranges; invalid or malformed references are left unchanged
+     * (the raw `&...` sequence remains in the output). If the input contains no `&` characters it is
+     * returned unchanged. A `null` input yields an empty string.
+     *
+     * @param text the text possibly containing XML entities or numeric references
+     * @return the text with entities and numeric references decoded; empty string when `text` is `null`
      */
     @SuppressWarnings("java:S135") // Multiple continue statements are natural for this single-pass scanner
     public static String unescapeTextContent(String text) {

--- a/core/src/main/java/eu/maveniverse/domtrip/Text.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Text.java
@@ -382,18 +382,12 @@ public class Text extends Node {
     }
 
     /**
-     * Convert XML character and entity references in the given text to their corresponding characters.
-     *
-     * <p>Supports named entities `&lt;`, `&gt;`, `&amp;`, `&quot;`, `&apos;` and numeric character references
-     * in decimal (`&#DDDD;`) and hexadecimal (`&#xHHHH;` / `&#XHHHH;`). Numeric references are validated
-     * against XML 1.0 allowed code point ranges; invalid or malformed references are left unchanged
-     * (the raw `&...` sequence remains in the output). If the input contains no `&` characters it is
-     * returned unchanged. A `null` input yields an empty string.
+     * Unescapes XML entities in text content, including numeric character references.
      *
      * @param text the text possibly containing XML entities or numeric references
-     * @return the text with entities and numeric references decoded; empty string when `text` is `null`
+     * @return the text with entities and numeric references decoded; empty string when {@code text} is {@code null}
      */
-    @SuppressWarnings("java:S135") // Multiple continue statements are natural for this single-pass scanner
+    @SuppressWarnings({"java:S135", "java:S3776"}) // Single-pass entity scanner has inherent branching complexity
     public static String unescapeTextContent(String text) {
         if (text == null) return "";
 

--- a/core/src/main/java/eu/maveniverse/domtrip/Text.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Text.java
@@ -329,11 +329,44 @@ public class Text extends Node {
     }
 
     /**
-     * Escapes special characters in text content
+     * Escapes special characters in text content.
+     * Uses a fast-path check to avoid allocation when no special chars are present.
      */
-    private String escapeTextContent(String text) {
+    static String escapeTextContent(String text) {
         if (text == null) return "";
-        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+
+        // Fast path: scan for any character that needs escaping
+        int len = text.length();
+        int firstSpecial = -1;
+        for (int i = 0; i < len; i++) {
+            char c = text.charAt(i);
+            if (c == '&' || c == '<' || c == '>') {
+                firstSpecial = i;
+                break;
+            }
+        }
+        if (firstSpecial < 0) {
+            return text; // No escaping needed — common case
+        }
+
+        // Single-pass escape from the first special character
+        StringBuilder sb = new StringBuilder(len + 16);
+        if (firstSpecial > 0) {
+            sb.append(text, 0, firstSpecial);
+        }
+        for (int i = firstSpecial; i < len; i++) {
+            char c = text.charAt(i);
+            if (c == '&') {
+                sb.append("&amp;");
+            } else if (c == '<') {
+                sb.append("&lt;");
+            } else if (c == '>') {
+                sb.append("&gt;");
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     /**
@@ -343,10 +376,21 @@ public class Text extends Node {
     public static String unescapeTextContent(String text) {
         if (text == null) return "";
 
+        // Fast path: if no '&' exists, no unescaping is needed.
+        // This is the common case for most element text content.
+        int ampIdx = text.indexOf('&');
+        if (ampIdx < 0) {
+            return text;
+        }
+
         // Single-pass scanner: resolve numeric references and named entities in one pass
         // to avoid re-decoding (e.g., &#38;lt; must yield "&lt;", not "<")
-        StringBuilder result = new StringBuilder();
-        int i = 0;
+        StringBuilder result = new StringBuilder(text.length());
+        // Bulk-copy everything before the first '&'
+        if (ampIdx > 0) {
+            result.append(text, 0, ampIdx);
+        }
+        int i = ampIdx;
         while (i < text.length()) {
             if (text.charAt(i) == '&') {
                 // Try numeric reference first

--- a/core/src/test/java/eu/maveniverse/domtrip/ParserBenchmark.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/ParserBenchmark.java
@@ -47,6 +47,15 @@ public class ParserBenchmark {
     private Document mediumDoc;
     private Document largeDoc;
 
+    /**
+     * Prepares benchmark state by creating a Parser, constructing XML input strings of various sizes,
+     * and parsing the medium/large/small inputs into Documents used by serialization benchmarks.
+     *
+     * <p>This method is executed once per benchmark instance to initialize:
+     * - the Parser under test,
+     * - the tiny, small, medium, and large XML input strings,
+     * - pre-parsed Document instances for small, medium, and large inputs used by serialization-only benchmarks.
+     */
     @Setup
     public void setup() {
         parser = new Parser();
@@ -60,68 +69,124 @@ public class ParserBenchmark {
         largeDoc = parser.parse(largeXml);
     }
 
-    // --- Parsing benchmarks ---
+    /**
+     * Parse the predefined tiny XML input into a Document.
+     *
+     * @return the parsed Document representing the tiny XML input
+     */
 
     @Benchmark
     public Document parseTiny() {
         return parser.parse(tinyXml);
     }
 
+    /**
+     * Parses the predefined small XML input into a Document.
+     *
+     * @return the parsed Document representing the small XML input
+     */
     @Benchmark
     public Document parseSmall() {
         return parser.parse(smallXml);
     }
 
+    /**
+     * Parse the medium-sized XML input.
+     *
+     * @return the parsed Document representing the medium XML input
+     */
     @Benchmark
     public Document parseMedium() {
         return parser.parse(mediumXml);
     }
 
+    /**
+     * Parses the prebuilt large XML input into a Document.
+     *
+     * @return the parsed large XML as a Document
+     */
     @Benchmark
     public Document parseLarge() {
         return parser.parse(largeXml);
     }
 
-    // --- Round-trip benchmarks (parse + serialize) ---
+    /**
+     * Parses the small XML input and serializes the resulting document back to XML.
+     *
+     * @return the serialized XML string produced from the small input
+     */
 
     @Benchmark
     public String roundTripSmall() {
         return parser.parse(smallXml).toXml();
     }
 
+    /**
+     * Parses the medium-sized XML test input and serializes the resulting document back to an XML string.
+     *
+     * @return the serialized XML produced from the medium-sized input
+     */
     @Benchmark
     public String roundTripMedium() {
         return parser.parse(mediumXml).toXml();
     }
 
+    /**
+     * Parses the large XML test input and serializes the resulting document back to an XML string.
+     *
+     * @return the serialized XML string produced from parsing the large XML input
+     */
     @Benchmark
     public String roundTripLarge() {
         return parser.parse(largeXml).toXml();
     }
 
-    // --- Serialization-only benchmarks ---
+    /**
+     * Serializes the pre-parsed small-sized XML Document to its XML string representation.
+     *
+     * @return the XML string representation of the pre-parsed small document
+     */
 
     @Benchmark
     public String serializeSmall() {
         return smallDoc.toXml();
     }
 
+    /**
+     * Serializes the pre-parsed medium-sized Document to its XML string representation.
+     *
+     * @return the XML string representation of the medium-sized document
+     */
     @Benchmark
     public String serializeMedium() {
         return mediumDoc.toXml();
     }
 
+    /**
+     * Serialize the pre-parsed large XML Document to its XML string representation.
+     *
+     * @return the XML string representation of the pre-parsed large document
+     */
     @Benchmark
     public String serializeLarge() {
         return largeDoc.toXml();
     }
 
-    // --- Test data builders ---
+    /**
+     * Builds a minimal XML string used as the smallest benchmark input.
+     *
+     * @return the XML string "<root><child>text</child></root>"
+     */
 
     private static String buildTinyXml() {
         return "<root><child>text</child></root>";
     }
 
+    /**
+     * Create a small Maven POM XML string used as benchmark input.
+     *
+     * @return the XML content of a small Maven POM as a String
+     */
     private static String buildSmallXml() {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n"
@@ -150,6 +215,17 @@ public class ParserBenchmark {
                 + "</project>\n";
     }
 
+    /**
+     * Builds a medium-sized Maven POM XML string used as benchmark input.
+     *
+     * <p>The generated XML includes a project header and:
+     * - a parent declaration and basic coordinates,
+     * - a <properties> section with 20 generated properties,
+     * - a <dependencies> section with 20 generated dependencies (some include `<scope>` or `<optional>`),
+     * - a <build><plugins> section with 5 generated plugins and simple configuration entries.
+     *
+     * @return the XML content of a medium-sized Maven POM used for parsing and serialization benchmarks
+     */
     private static String buildMediumXml() {
         StringBuilder sb = new StringBuilder();
         sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -219,6 +295,16 @@ public class ParserBenchmark {
         return sb.toString();
     }
 
+    /**
+     * Builds a large Maven POM XML string used as a benchmark input.
+     *
+     * The generated XML represents a complete POM with many generated entries:
+     * properties, dependencyManagement, a large set of dependencies (with conditional
+     * scopes and exclusions), a build/plugins section with multiple plugins and
+     * optional executions, and several profiles each containing dependencies.
+     *
+     * @return the generated POM XML as a String
+     */
     private static String buildLargeXml() {
         StringBuilder sb = new StringBuilder();
         sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
@@ -366,6 +452,14 @@ public class ParserBenchmark {
         new Runner(opt).run();
     }
 
+    /**
+     * Entrypoint to execute the JMH benchmarks defined by ParserBenchmark.
+     *
+     * Builds JMH options that include this benchmark class and runs the JMH Runner.
+     *
+     * @param args command-line arguments (ignored)
+     * @throws Exception if the JMH runner fails to execute the benchmarks
+     */
     public static void main(String[] args) throws Exception {
         Options opt = new OptionsBuilder()
                 .include(ParserBenchmark.class.getSimpleName())

--- a/core/src/test/java/eu/maveniverse/domtrip/ParserBenchmark.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/ParserBenchmark.java
@@ -7,6 +7,9 @@
  */
 package eu.maveniverse.domtrip;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -34,6 +37,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(1)
+@SuppressWarnings("java:S3577") // JMH benchmark class does not follow test naming convention
 public class ParserBenchmark {
 
     private Parser parser;
@@ -74,7 +78,6 @@ public class ParserBenchmark {
      *
      * @return the parsed Document representing the tiny XML input
      */
-
     @Benchmark
     public Document parseTiny() {
         return parser.parse(tinyXml);
@@ -115,7 +118,6 @@ public class ParserBenchmark {
      *
      * @return the serialized XML string produced from the small input
      */
-
     @Benchmark
     public String roundTripSmall() {
         return parser.parse(smallXml).toXml();
@@ -146,7 +148,6 @@ public class ParserBenchmark {
      *
      * @return the XML string representation of the pre-parsed small document
      */
-
     @Benchmark
     public String serializeSmall() {
         return smallDoc.toXml();
@@ -177,7 +178,6 @@ public class ParserBenchmark {
      *
      * @return the XML string "<root><child>text</child></root>"
      */
-
     private static String buildTinyXml() {
         return "<root><child>text</child></root>";
     }
@@ -217,14 +217,9 @@ public class ParserBenchmark {
 
     /**
      * Builds a medium-sized Maven POM XML string used as benchmark input.
+     * Includes 20 properties, 20 dependencies, and 5 plugins.
      *
-     * <p>The generated XML includes a project header and:
-     * - a parent declaration and basic coordinates,
-     * - a <properties> section with 20 generated properties,
-     * - a <dependencies> section with 20 generated dependencies (some include `<scope>` or `<optional>`),
-     * - a <build><plugins> section with 5 generated plugins and simple configuration entries.
-     *
-     * @return the XML content of a medium-sized Maven POM used for parsing and serialization benchmarks
+     * @return the XML content of a medium-sized Maven POM
      */
     private static String buildMediumXml() {
         StringBuilder sb = new StringBuilder();
@@ -449,7 +444,8 @@ public class ParserBenchmark {
         Options opt = new OptionsBuilder()
                 .include(ParserBenchmark.class.getSimpleName())
                 .build();
-        new Runner(opt).run();
+        Collection<?> results = new Runner(opt).run();
+        assertFalse(results.isEmpty(), "JMH should have produced benchmark results");
     }
 
     /**

--- a/core/src/test/java/eu/maveniverse/domtrip/ParserBenchmark.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/ParserBenchmark.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH benchmarks for DomTrip parser performance.
+ *
+ * <p>Run via main method or: {@code java -cp ... org.openjdk.jmh.Main ParserBenchmark}</p>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class ParserBenchmark {
+
+    private Parser parser;
+    private String tinyXml;
+    private String smallXml;
+    private String mediumXml;
+    private String largeXml;
+
+    // Pre-parsed documents for serialization benchmarks
+    private Document smallDoc;
+    private Document mediumDoc;
+    private Document largeDoc;
+
+    @Setup
+    public void setup() {
+        parser = new Parser();
+        tinyXml = buildTinyXml();
+        smallXml = buildSmallXml();
+        mediumXml = buildMediumXml();
+        largeXml = buildLargeXml();
+
+        smallDoc = parser.parse(smallXml);
+        mediumDoc = parser.parse(mediumXml);
+        largeDoc = parser.parse(largeXml);
+    }
+
+    // --- Parsing benchmarks ---
+
+    @Benchmark
+    public Document parseTiny() {
+        return parser.parse(tinyXml);
+    }
+
+    @Benchmark
+    public Document parseSmall() {
+        return parser.parse(smallXml);
+    }
+
+    @Benchmark
+    public Document parseMedium() {
+        return parser.parse(mediumXml);
+    }
+
+    @Benchmark
+    public Document parseLarge() {
+        return parser.parse(largeXml);
+    }
+
+    // --- Round-trip benchmarks (parse + serialize) ---
+
+    @Benchmark
+    public String roundTripSmall() {
+        return parser.parse(smallXml).toXml();
+    }
+
+    @Benchmark
+    public String roundTripMedium() {
+        return parser.parse(mediumXml).toXml();
+    }
+
+    @Benchmark
+    public String roundTripLarge() {
+        return parser.parse(largeXml).toXml();
+    }
+
+    // --- Serialization-only benchmarks ---
+
+    @Benchmark
+    public String serializeSmall() {
+        return smallDoc.toXml();
+    }
+
+    @Benchmark
+    public String serializeMedium() {
+        return mediumDoc.toXml();
+    }
+
+    @Benchmark
+    public String serializeLarge() {
+        return largeDoc.toXml();
+    }
+
+    // --- Test data builders ---
+
+    private static String buildTinyXml() {
+        return "<root><child>text</child></root>";
+    }
+
+    private static String buildSmallXml() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n"
+                + "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                + "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>my-app</artifactId>\n"
+                + "  <version>1.0.0-SNAPSHOT</version>\n"
+                + "  <packaging>jar</packaging>\n"
+                + "\n"
+                + "  <properties>\n"
+                + "    <maven.compiler.release>17</maven.compiler.release>\n"
+                + "    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>\n"
+                + "  </properties>\n"
+                + "\n"
+                + "  <dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>org.junit.jupiter</groupId>\n"
+                + "      <artifactId>junit-jupiter</artifactId>\n"
+                + "      <version>5.10.0</version>\n"
+                + "      <scope>test</scope>\n"
+                + "    </dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+    }
+
+    private static String buildMediumXml() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<!-- This is a medium-sized POM file for benchmarking -->\n");
+        sb.append("<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n");
+        sb.append("         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n");
+        sb.append(
+                "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n");
+        sb.append("  <modelVersion>4.0.0</modelVersion>\n\n");
+        sb.append("  <parent>\n");
+        sb.append("    <groupId>com.example</groupId>\n");
+        sb.append("    <artifactId>parent</artifactId>\n");
+        sb.append("    <version>1.0.0</version>\n");
+        sb.append("  </parent>\n\n");
+        sb.append("  <groupId>com.example</groupId>\n");
+        sb.append("  <artifactId>medium-app</artifactId>\n");
+        sb.append("  <version>2.0.0-SNAPSHOT</version>\n");
+        sb.append("  <packaging>jar</packaging>\n");
+        sb.append("  <name>Medium Application</name>\n");
+        sb.append(
+                "  <description>A medium-sized application for &amp; benchmarking &lt;purposes&gt;</description>\n\n");
+
+        sb.append("  <properties>\n");
+        for (int i = 0; i < 20; i++) {
+            sb.append("    <property.name")
+                    .append(i)
+                    .append(">value")
+                    .append(i)
+                    .append("</property.name")
+                    .append(i)
+                    .append(">\n");
+        }
+        sb.append("  </properties>\n\n");
+
+        sb.append("  <dependencies>\n");
+        for (int i = 0; i < 20; i++) {
+            sb.append("    <dependency>\n");
+            sb.append("      <groupId>com.example.group").append(i).append("</groupId>\n");
+            sb.append("      <artifactId>artifact-").append(i).append("</artifactId>\n");
+            sb.append("      <version>").append(i).append(".0.0</version>\n");
+            if (i % 3 == 0) {
+                sb.append("      <scope>test</scope>\n");
+            }
+            if (i % 5 == 0) {
+                sb.append("      <optional>true</optional>\n");
+            }
+            sb.append("    </dependency>\n");
+        }
+        sb.append("  </dependencies>\n\n");
+
+        sb.append("  <build>\n");
+        sb.append("    <plugins>\n");
+        for (int i = 0; i < 5; i++) {
+            sb.append("      <plugin>\n");
+            sb.append("        <groupId>org.apache.maven.plugins</groupId>\n");
+            sb.append("        <artifactId>maven-plugin-").append(i).append("</artifactId>\n");
+            sb.append("        <version>3.").append(i).append(".0</version>\n");
+            sb.append("        <configuration>\n");
+            sb.append("          <param1>value1</param1>\n");
+            sb.append("          <param2>value2</param2>\n");
+            sb.append("        </configuration>\n");
+            sb.append("      </plugin>\n");
+        }
+        sb.append("    </plugins>\n");
+        sb.append("  </build>\n");
+        sb.append("</project>\n");
+        return sb.toString();
+    }
+
+    private static String buildLargeXml() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<!--\n  Large POM file for benchmarking.\n  Contains many dependencies and plugins.\n-->\n");
+        sb.append("<project xmlns=\"http://maven.apache.org/POM/4.0.0\"\n");
+        sb.append("         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n");
+        sb.append(
+                "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd\">\n");
+        sb.append("  <modelVersion>4.0.0</modelVersion>\n\n");
+        sb.append("  <groupId>com.example</groupId>\n");
+        sb.append("  <artifactId>large-app</artifactId>\n");
+        sb.append("  <version>3.0.0-SNAPSHOT</version>\n\n");
+
+        sb.append("  <properties>\n");
+        for (int i = 0; i < 50; i++) {
+            sb.append("    <version.lib")
+                    .append(i)
+                    .append(">")
+                    .append(i)
+                    .append(".")
+                    .append(i % 10)
+                    .append(".0</version.lib")
+                    .append(i)
+                    .append(">\n");
+        }
+        sb.append("  </properties>\n\n");
+
+        sb.append("  <dependencyManagement>\n");
+        sb.append("    <dependencies>\n");
+        for (int i = 0; i < 50; i++) {
+            sb.append("      <dependency>\n");
+            sb.append("        <groupId>com.example.managed").append(i).append("</groupId>\n");
+            sb.append("        <artifactId>managed-artifact-").append(i).append("</artifactId>\n");
+            sb.append("        <version>${version.lib").append(i).append("}</version>\n");
+            if (i % 4 == 0) {
+                sb.append("        <type>pom</type>\n");
+                sb.append("        <scope>import</scope>\n");
+            }
+            sb.append("      </dependency>\n");
+        }
+        sb.append("    </dependencies>\n");
+        sb.append("  </dependencyManagement>\n\n");
+
+        sb.append("  <dependencies>\n");
+        for (int i = 0; i < 100; i++) {
+            sb.append("    <dependency>\n");
+            sb.append("      <groupId>com.example.dep").append(i).append("</groupId>\n");
+            sb.append("      <artifactId>dep-artifact-").append(i).append("</artifactId>\n");
+            sb.append("      <version>")
+                    .append(i % 10)
+                    .append(".")
+                    .append(i % 5)
+                    .append(".")
+                    .append(i % 3)
+                    .append("</version>\n");
+            if (i % 3 == 0) {
+                sb.append("      <scope>test</scope>\n");
+            } else if (i % 7 == 0) {
+                sb.append("      <scope>provided</scope>\n");
+            }
+            if (i % 10 == 0) {
+                sb.append("      <exclusions>\n");
+                sb.append("        <exclusion>\n");
+                sb.append("          <groupId>com.excluded</groupId>\n");
+                sb.append("          <artifactId>excluded-").append(i).append("</artifactId>\n");
+                sb.append("        </exclusion>\n");
+                sb.append("      </exclusions>\n");
+            }
+            sb.append("    </dependency>\n");
+        }
+        sb.append("  </dependencies>\n\n");
+
+        sb.append("  <build>\n");
+        sb.append("    <plugins>\n");
+        String[] pluginNames = {
+            "compiler", "surefire", "jar", "install", "deploy",
+            "site", "clean", "resources", "source", "javadoc",
+            "shade", "assembly", "dependency", "enforcer", "failsafe"
+        };
+        for (int i = 0; i < 15; i++) {
+            sb.append("      <plugin>\n");
+            sb.append("        <groupId>org.apache.maven.plugins</groupId>\n");
+            sb.append("        <artifactId>maven-")
+                    .append(pluginNames[i % pluginNames.length])
+                    .append("-plugin</artifactId>\n");
+            sb.append("        <version>3.").append(i).append(".0</version>\n");
+            sb.append("        <configuration>\n");
+            for (int j = 0; j < 5; j++) {
+                sb.append("          <config")
+                        .append(j)
+                        .append(">value-")
+                        .append(j)
+                        .append("</config")
+                        .append(j)
+                        .append(">\n");
+            }
+            sb.append("        </configuration>\n");
+            if (i % 3 == 0) {
+                sb.append("        <executions>\n");
+                sb.append("          <execution>\n");
+                sb.append("            <id>exec-").append(i).append("</id>\n");
+                sb.append("            <phase>compile</phase>\n");
+                sb.append("            <goals>\n");
+                sb.append("              <goal>run</goal>\n");
+                sb.append("            </goals>\n");
+                sb.append("          </execution>\n");
+                sb.append("        </executions>\n");
+            }
+            sb.append("      </plugin>\n");
+        }
+        sb.append("    </plugins>\n");
+        sb.append("  </build>\n\n");
+
+        sb.append("  <profiles>\n");
+        for (int i = 0; i < 5; i++) {
+            sb.append("    <profile>\n");
+            sb.append("      <id>profile-").append(i).append("</id>\n");
+            sb.append("      <activation>\n");
+            sb.append("        <property>\n");
+            sb.append("          <name>env</name>\n");
+            sb.append("          <value>").append(i % 2 == 0 ? "prod" : "dev").append("</value>\n");
+            sb.append("        </property>\n");
+            sb.append("      </activation>\n");
+            sb.append("      <dependencies>\n");
+            for (int j = 0; j < 5; j++) {
+                sb.append("        <dependency>\n");
+                sb.append("          <groupId>com.profile").append(i).append("</groupId>\n");
+                sb.append("          <artifactId>profile-dep-").append(j).append("</artifactId>\n");
+                sb.append("          <version>1.0.0</version>\n");
+                sb.append("        </dependency>\n");
+            }
+            sb.append("      </dependencies>\n");
+            sb.append("    </profile>\n");
+        }
+        sb.append("  </profiles>\n");
+        sb.append("</project>\n");
+        return sb.toString();
+    }
+
+    @Test
+    void runBenchmarks() throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(ParserBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(ParserBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
## Summary

- Optimize Parser, Element, Text, and Attribute hot paths to reduce allocations and improve throughput on typical Maven POM files
- Add JMH microbenchmark suite for reproducible performance measurement (excluded from normal test runs)
- All 1235 existing tests pass unchanged

### Key optimizations

- **Parser**: bulk text collection via substring, whitespace position tracking instead of StringBuilder per attribute, fast-path whitespace check, source-backed indices for original tags
- **Element**: lazy String materialization for original open/close tags, direct `sb.append(source, start, end)` during serialization
- **Text**: fast-path short-circuit in unescape/escape when no special chars present, single-pass escape
- **Attribute**: single-pass escape with fast-path

### JMH benchmark results (us/op, lower is better)

| Benchmark | Before | After | Speedup |
|---|---|---|---|
| parseTiny | 0.234 | 0.201 | 1.2x |
| parseSmall | 5.901 | 2.587 | **2.3x** |
| parseMedium | 50.849 | 21.528 | **2.4x** |
| parseLarge | 302.797 | 127.900 | **2.4x** |
| roundTripSmall | 5.222 | 3.054 | **1.7x** |
| roundTripMedium | 67.221 | 28.765 | **2.3x** |
| roundTripLarge | 370.022 | 182.145 | **2.0x** |
| serializeSmall | 0.594 | 0.567 | ~ |
| serializeMedium | 5.266 | 5.699 | ~ |
| serializeLarge | 48.114 | 49.317 | ~ |

Serialization is unchanged (expected — optimizations target the parse path).

## Test plan

- [x] All 1235 core tests pass
- [x] JMH benchmarks run successfully: `mvn test -B -pl core -Dtest=ParserBenchmark`
- [ ] Verify round-trip fidelity on real-world POM files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added JMH performance benchmarks and a test harness for parsing and serialization across multiple input sizes; includes a runnable entry and JUnit integration.

* **Chores**
  * Updated build to include JMH test dependencies, enable annotation processing for benchmarks, and exclude benchmark/generated classes from normal test runs.

* **Refactor**
  * Parser and text/attribute escaping refactors for faster, lower-allocation parsing/serialization and improved preservation of original tag text and XML whitespace handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->