### PR TITLE
docs: add thread-safety documentation to core classes

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Attribute.java
@@ -21,7 +21,7 @@ package eu.maveniverse.domtrip;
  *   <li><strong>Quote Style Preservation</strong> - Maintains single vs double quotes</li>
  *   <li><strong>Whitespace Preservation</strong> - Preserves spacing before attributes</li>
  *   <li><strong>Entity Preservation</strong> - Maintains original entity encoding</li>
- *   <li><strong>Immutable Design</strong> - Thread-safe with builder pattern support</li>
+ *   <li><strong>Fluent Mutation</strong> - Mutable setters with method chaining, plus immutable-style {@code withX()} methods</li>
  *   <li><strong>Fluent API</strong> - Creation and modification with method chaining</li>
  * </ul>
  *

--- a/core/src/main/java/eu/maveniverse/domtrip/Document.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Document.java
@@ -72,6 +72,8 @@ import java.util.stream.Collectors;
  *   <li>An optional DOCTYPE declaration</li>
  * </ul>
  *
+ * @implNote This class is not thread-safe. External synchronization is required for concurrent access.
+ *
  * @see Element
  * @see ContainerNode
  * @see Parser

--- a/core/src/main/java/eu/maveniverse/domtrip/Element.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Element.java
@@ -76,6 +76,9 @@ import java.util.stream.Stream;
  * element.attributeObject("class").value("manual");
  * }</pre>
  *
+ * @implNote This class is not thread-safe. It uses mutable state and lazy materialization
+ * (e.g., {@link #originalOpenTag()}) with no synchronization.
+ *
  * @see ContainerNode
  * @see Attribute
  * @see NamespaceContext

--- a/core/src/main/java/eu/maveniverse/domtrip/Element.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Element.java
@@ -76,8 +76,7 @@ import java.util.stream.Stream;
  * element.attributeObject("class").value("manual");
  * }</pre>
  *
- * @implNote This class is not thread-safe. It uses mutable state and lazy materialization
- * (e.g., {@link #originalOpenTag()}) with no synchronization.
+ * @implNote This class is not thread-safe. It uses mutable state with no synchronization.
  *
  * @see ContainerNode
  * @see Attribute

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -86,6 +86,9 @@ import java.util.regex.Pattern;
  * }
  * }</pre>
  *
+ * @implNote This class is not thread-safe. It uses instance fields to track parse state.
+ * A single instance may be reused for sequential parses but must not be shared across threads.
+ *
  * @see Document
  * @see Element
  * @see DomTripException

--- a/core/src/main/java/eu/maveniverse/domtrip/package-info.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/package-info.java
@@ -90,6 +90,14 @@
  * String prefix = element.prefix();
  * }</pre>
  *
+ * <h2>Thread Safety</h2>
+ * <p>All types in this package are <strong>not thread-safe</strong>. The DOM tree uses mutable state
+ * and lazy materialization with no synchronization, consistent with standard DOM APIs
+ * (e.g., {@code org.w3c.dom}). External synchronization is required for concurrent access
+ * to any node in a DOM tree. {@link eu.maveniverse.domtrip.Parser} instances also use mutable
+ * state to track parse position and must not be shared across threads concurrently, but may be
+ * reused sequentially.</p>
+ *
  * @version 1.0
  */
 package eu.maveniverse.domtrip;


### PR DESCRIPTION
## Summary
- Add a "Thread Safety" section to `package-info.java` stating the overall concurrency contract: all types are not thread-safe, consistent with `org.w3c.dom`
- Add `@implNote` thread-safety notes to `Document`, `Element`, and `Parser` class javadocs
- Fix misleading "Immutable Design - Thread-safe with builder pattern support" claim in `Attribute.java` — replaced with accurate description of mutable setters + immutable-style `withX()` methods

## Test plan
- [x] Javadoc-only changes — no behavioral change
- [x] Spotless clean (`mvn spotless:apply` reports 0 changes)
- [x] CI build should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified thread-safety: library components are not thread-safe and require external synchronization for concurrent access; parser instances may be reused sequentially but must not be shared concurrently.
  * Updated design description to reflect a fluent-mutation style with mutable setters and optional immutable-style convenience methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->