### PR TITLE
fix: preserve whitespace between XML declaration and DOCTYPE

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/Document.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Document.java
@@ -200,6 +200,13 @@ public class Document extends ContainerNode {
     }
 
     /**
+     * Sets the XML declaration without marking the document as modified (for internal use during parsing).
+     */
+    void xmlDeclarationInternal(String xmlDeclaration) {
+        this.xmlDeclaration = xmlDeclaration != null ? xmlDeclaration : "";
+    }
+
+    /**
      * Gets the DOCTYPE declaration for this document.
      *
      * <p>The DOCTYPE declaration defines the document type and may include
@@ -230,6 +237,26 @@ public class Document extends ContainerNode {
         this.doctype = doctype != null ? doctype : "";
         markModified();
         return this;
+    }
+
+    /**
+     * Sets the DOCTYPE declaration without marking the document as modified (for internal use during parsing).
+     */
+    void doctypeInternal(String doctype) {
+        this.doctype = doctype != null ? doctype : "";
+    }
+
+    /**
+     * Gets the whitespace before the DOCTYPE declaration.
+     *
+     * <p>This whitespace appears between the XML declaration and the DOCTYPE
+     * declaration. It is preserved during round-trip parsing and serialization
+     * to maintain document fidelity.</p>
+     *
+     * @return the whitespace before the DOCTYPE declaration, or empty string if none
+     */
+    public String doctypePrecedingWhitespace() {
+        return doctypePrecedingWhitespace;
     }
 
     /**
@@ -321,6 +348,13 @@ public class Document extends ContainerNode {
     }
 
     /**
+     * Sets the encoding without marking the document as modified (for internal use during parsing).
+     */
+    void encodingInternal(String encoding) {
+        this.encoding = encoding != null ? encoding : DEFAULT_ENCODING;
+    }
+
+    /**
      * Gets the XML version for this document.
      *
      * <p>The XML version indicates which version of the XML specification
@@ -347,6 +381,13 @@ public class Document extends ContainerNode {
         this.version = version != null ? version : "1.0";
         markModified();
         return this;
+    }
+
+    /**
+     * Sets the version without marking the document as modified (for internal use during parsing).
+     */
+    void versionInternal(String version) {
+        this.version = version != null ? version : "1.0";
     }
 
     /**
@@ -377,6 +418,13 @@ public class Document extends ContainerNode {
         this.standalone = standalone;
         markModified();
         return this;
+    }
+
+    /**
+     * Sets the standalone flag without marking the document as modified (for internal use during parsing).
+     */
+    void standaloneInternal(boolean standalone) {
+        this.standalone = standalone;
     }
 
     /**

--- a/core/src/main/java/eu/maveniverse/domtrip/Document.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Document.java
@@ -200,7 +200,11 @@ public class Document extends ContainerNode {
     }
 
     /**
-     * Sets the XML declaration without marking the document as modified (for internal use during parsing).
+     * Set the XML declaration without marking the document as modified.
+     *
+     * Normalizes a null value to an empty string; intended for internal use (e.g., during parsing).
+     *
+     * @param xmlDeclaration the XML declaration text, or `null` to clear it (stored as an empty string)
      */
     void xmlDeclarationInternal(String xmlDeclaration) {
         this.xmlDeclaration = xmlDeclaration != null ? xmlDeclaration : "";
@@ -240,7 +244,9 @@ public class Document extends ContainerNode {
     }
 
     /**
-     * Sets the DOCTYPE declaration without marking the document as modified (for internal use during parsing).
+     * Set the DOCTYPE declaration without marking the document as modified.
+     *
+     * @param doctype the DOCTYPE text to set; {@code null} is treated as the empty string
      */
     void doctypeInternal(String doctype) {
         this.doctype = doctype != null ? doctype : "";
@@ -331,13 +337,11 @@ public class Document extends ContainerNode {
     }
 
     /**
-     * Sets the character encoding for this document.
+     * Set the document's character encoding used for serialization.
      *
-     * <p>Setting this value marks the document as modified. The encoding
-     * affects how the document is serialized and should match the actual
-     * character encoding used.</p>
+     * <p>If {@code encoding} is {@code null}, the default {@code "UTF-8"} is used. This method marks the document as modified.</p>
      *
-     * @param encoding the character encoding to use, or null to use default "UTF-8"
+     * @param encoding the character encoding to use, or {@code null} to reset to the default {@code "UTF-8"}
      * @return this document for method chaining
      * @see #encoding()
      */
@@ -348,7 +352,9 @@ public class Document extends ContainerNode {
     }
 
     /**
-     * Sets the encoding without marking the document as modified (for internal use during parsing).
+     * Set the document's encoding without marking the document as modified (intended for internal use during parsing).
+     *
+     * @param encoding the encoding to set, or `null` to use {@code DEFAULT_ENCODING}
      */
     void encodingInternal(String encoding) {
         this.encoding = encoding != null ? encoding : DEFAULT_ENCODING;
@@ -368,13 +374,12 @@ public class Document extends ContainerNode {
     }
 
     /**
-     * Sets the XML version for this document.
+     * Set the XML version of this document.
      *
-     * <p>Setting this value marks the document as modified. Most documents
-     * should use version "1.0" unless specific XML 1.1 features are required.</p>
+     * <p>Marks the document as modified.</p>
      *
-     * @param version the XML version to use, or null to use default "1.0"
-     * @return this document for method chaining
+     * @param version the XML version to use, or null to use "1.0"
+     * @return this document
      * @see #version()
      */
     public Document version(String version) {
@@ -384,7 +389,9 @@ public class Document extends ContainerNode {
     }
 
     /**
-     * Sets the version without marking the document as modified (for internal use during parsing).
+     * Set the document's XML version without marking the document as modified.
+     *
+     * @param version the XML version to assign; if `null`, the version will be set to "1.0"
      */
     void versionInternal(String version) {
         this.version = version != null ? version : "1.0";
@@ -421,7 +428,9 @@ public class Document extends ContainerNode {
     }
 
     /**
-     * Sets the standalone flag without marking the document as modified (for internal use during parsing).
+     * Set the document's standalone flag without marking the document as modified.
+     *
+     * @param standalone true to indicate the document is standalone, false otherwise
      */
     void standaloneInternal(boolean standalone) {
         this.standalone = standalone;

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -408,7 +408,14 @@ public class Parser {
     }
 
     /**
-     * Parses a processing instruction tag starting with '<?'.
+     * Parses a processing instruction and either records it as the document's XML declaration
+     * (when it contains a `version` attribute) or attaches it as a ProcessingInstruction node
+     * to the current container.
+     *
+     * @param document the Document being constructed; used to store an XML declaration when present
+     * @param nodeStack the stack of open nodes whose peek is the current container for added nodes
+     * @param pendingWhitespace accumulated whitespace to attach to the created ProcessingInstruction node
+     * @throws DomTripException if the processing instruction is unterminated or otherwise malformed
      */
     private void parseProcessingInstructionTag(
             Document document, Deque<Node> nodeStack, StringBuilder pendingWhitespace) throws DomTripException {

--- a/core/src/main/java/eu/maveniverse/domtrip/Parser.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Parser.java
@@ -226,7 +226,7 @@ public class Parser {
             // This must happen AFTER updateDocumentFromXmlDeclaration, because the detected
             // encoding (from BOM or byte patterns) takes precedence over the declared encoding
             // in the XML declaration (which may be inaccurate).
-            document.encoding(detectedCharset.name());
+            document.encodingInternal(detectedCharset.name());
 
             return document;
 
@@ -397,7 +397,7 @@ public class Parser {
             ((ContainerNode) nodeStack.peek()).addChildInternal(cdata);
         } else if (position + 9 < length && xml.charAt(position + 2) == 'D' && xml.startsWith("<!DOCTYPE", position)) {
             String doctype = parseDoctype();
-            document.doctype(doctype);
+            document.doctypeInternal(doctype);
             if (pendingWhitespace.length() > 0) {
                 document.doctypePrecedingWhitespace(pendingWhitespace.toString());
                 pendingWhitespace.setLength(0);
@@ -414,7 +414,7 @@ public class Parser {
             Document document, Deque<Node> nodeStack, StringBuilder pendingWhitespace) throws DomTripException {
         String pi = parseProcessingInstruction();
         if (pi.startsWith(XML_DECL_PREFIX + " ") && pi.contains("version=")) {
-            document.xmlDeclaration(pi);
+            document.xmlDeclarationInternal(pi);
             updateDocumentFromXmlDeclaration(document, pi);
         } else {
             ProcessingInstruction piNode = new ProcessingInstruction(pi);
@@ -1042,13 +1042,13 @@ public class Parser {
             String standalone = matcher.group(3);
 
             if (version != null) {
-                document.version(version);
+                document.versionInternal(version);
             }
             if (encoding != null) {
-                document.encoding(encoding);
+                document.encodingInternal(encoding);
             }
             if (standalone != null) {
-                document.standalone("yes".equalsIgnoreCase(standalone));
+                document.standaloneInternal("yes".equalsIgnoreCase(standalone));
             }
         }
     }

--- a/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
@@ -549,6 +549,18 @@ public class Serializer {
         return sb.toString();
     }
 
+    /**
+     * Serializes the given node into the provided StringBuilder while applying preservation
+     * and filtering rules.
+     *
+     * <p>If the node is a comment or processing instruction and the corresponding preservation
+     * flag is disabled, the node is skipped. If the node is not a DOCUMENT and is unmodified,
+     * the node's original XML is appended via {@code node.toXml(sb)}. Otherwise the node is
+     * dispatched to the appropriate type-specific serializer.
+     *
+     * @param node the node to serialize
+     * @param sb the StringBuilder to append serialized XML to
+     */
     private void serializeNode(Node node, StringBuilder sb) {
         // Check filtering rules first (comments and PIs can be suppressed by config)
         if (node.type() == Node.NodeType.COMMENT && !preserveComments) {

--- a/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
@@ -308,26 +308,36 @@ public class Serializer {
         }
 
         StringBuilder sb = new StringBuilder();
+        serializeProlog(document, sb);
+        serializeChildren(document, sb);
+        return sb.toString();
+    }
 
+    private void serializeProlog(Document document, StringBuilder sb) {
         // Add XML declaration only if it was present in original and not omitted by config
-        if (!document.xmlDeclaration().isEmpty() && !omitXmlDeclaration) {
+        boolean hasXmlDeclaration = !document.xmlDeclaration().isEmpty();
+        if (hasXmlDeclaration && !omitXmlDeclaration) {
             sb.append(document.xmlDeclaration());
         }
 
         // Add DOCTYPE if present (with its preceding whitespace)
         if (!document.doctype().isEmpty()) {
-            boolean emittedXmlDeclaration = !document.xmlDeclaration().isEmpty() && !omitXmlDeclaration;
-            if (prettyPrint) {
-                if (!lineEnding.isEmpty()) {
-                    sb.append(lineEnding);
-                }
-            } else if (emittedXmlDeclaration || document.xmlDeclaration().isEmpty()) {
-                sb.append(document.doctypePrecedingWhitespace());
-            }
+            appendDoctypeWhitespace(document, sb, hasXmlDeclaration && !omitXmlDeclaration);
             sb.append(document.doctype());
         }
+    }
 
-        // Add document element and other children
+    private void appendDoctypeWhitespace(Document document, StringBuilder sb, boolean emittedXmlDeclaration) {
+        if (prettyPrint) {
+            if (!lineEnding.isEmpty()) {
+                sb.append(lineEnding);
+            }
+        } else if (emittedXmlDeclaration || document.xmlDeclaration().isEmpty()) {
+            sb.append(document.doctypePrecedingWhitespace());
+        }
+    }
+
+    private void serializeChildren(Document document, StringBuilder sb) {
         if (prettyPrint) {
             if (!lineEnding.isEmpty()) {
                 sb.append(lineEnding);
@@ -336,8 +346,6 @@ public class Serializer {
         } else {
             serializeNode(document, sb);
         }
-
-        return sb.toString();
     }
 
     /**

--- a/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
@@ -314,10 +314,12 @@ public class Serializer {
             sb.append(document.xmlDeclaration());
         }
 
-        // Add DOCTYPE if present
+        // Add DOCTYPE if present (with its preceding whitespace)
         if (!document.doctype().isEmpty()) {
             if (prettyPrint && !lineEnding.isEmpty()) {
                 sb.append(lineEnding);
+            } else {
+                sb.append(document.doctypePrecedingWhitespace());
             }
             sb.append(document.doctype());
         }
@@ -550,8 +552,10 @@ public class Serializer {
             return;
         }
 
-        if (!node.isModified()) {
-            // Use original formatting for unmodified nodes when not pretty printing
+        if (node.type() != Node.NodeType.DOCUMENT && !node.isModified()) {
+            // Use original formatting for unmodified nodes when not pretty printing.
+            // Document nodes are excluded because serialize(Document) handles the XML
+            // declaration and DOCTYPE separately, and children need filtering applied.
             node.toXml(sb);
             return;
         }

--- a/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
@@ -316,9 +316,12 @@ public class Serializer {
 
         // Add DOCTYPE if present (with its preceding whitespace)
         if (!document.doctype().isEmpty()) {
-            if (prettyPrint && !lineEnding.isEmpty()) {
-                sb.append(lineEnding);
-            } else {
+            boolean emittedXmlDeclaration = !document.xmlDeclaration().isEmpty() && !omitXmlDeclaration;
+            if (prettyPrint) {
+                if (!lineEnding.isEmpty()) {
+                    sb.append(lineEnding);
+                }
+            } else if (emittedXmlDeclaration || document.xmlDeclaration().isEmpty()) {
                 sb.append(document.doctypePrecedingWhitespace());
             }
             sb.append(document.doctype());
@@ -527,6 +530,9 @@ public class Serializer {
     public String serialize(Node node) {
         if (node == null) {
             return "";
+        }
+        if (node.type() == Node.NodeType.DOCUMENT) {
+            return serialize((Document) node);
         }
 
         if (!prettyPrint && !node.isModified()) {

--- a/core/src/test/java/eu/maveniverse/domtrip/DoctypePreservationTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/DoctypePreservationTest.java
@@ -190,6 +190,42 @@ class DoctypePreservationTest {
     }
 
     @Test
+    void testDoctypeWhitespaceNotLeakedWhenXmlDeclarationOmitted() throws DomTripException {
+        String xml = "<?xml version=\"1.0\"?>\n<!DOCTYPE root>\n<root/>";
+        Document doc = Document.of(xml);
+
+        // Serialize with omitXmlDeclaration - the whitespace between declaration and
+        // DOCTYPE should not leak as leading whitespace
+        DomTripConfig config = DomTripConfig.defaults().withXmlDeclaration(false);
+        Serializer serializer = new Serializer(config);
+        String result = serializer.serialize(doc);
+        assertTrue(result.startsWith("<!DOCTYPE root>"));
+    }
+
+    @Test
+    void testSerializeNodeDelegatesToSerializeDocumentForDocumentNodes() throws DomTripException {
+        String xml = "<?xml version=\"1.0\"?>\n<!-- comment -->\n<root/>";
+        Document doc = Document.of(xml);
+
+        // Using minimal config (omits comments) through serialize(Node) should still
+        // apply comment filtering by delegating to serialize(Document)
+        Serializer serializer = new Serializer(DomTripConfig.minimal());
+        String result = serializer.serialize((Node) doc);
+        assertFalse(result.contains("<!--"));
+    }
+
+    @Test
+    void testDoctypeWhitespacePreservedWithPrettyPrint() throws DomTripException {
+        String xml = "<?xml version=\"1.0\"?>\n<!DOCTYPE root>\n<root/>";
+        Document doc = Document.of(xml);
+
+        Serializer serializer = new Serializer(DomTripConfig.prettyPrint());
+        String result = serializer.serialize(doc);
+        assertTrue(result.contains("<?xml version=\"1.0\"?>"));
+        assertTrue(result.contains("<!DOCTYPE root>"));
+    }
+
+    @Test
     void testLosslessRoundTrip() throws DomTripException {
         String originalXml = """
             <?xml version="1.0" encoding="UTF-8"?>

--- a/core/src/test/java/eu/maveniverse/domtrip/DoctypePreservationTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/DoctypePreservationTest.java
@@ -182,7 +182,9 @@ class DoctypePreservationTest {
         Element name = root.childElement("name").orElseThrow();
         name.textContent("modified");
 
-        String result = doc.toXml();
+        // Use Editor.toXml() to exercise the Serializer fallback path
+        Editor editor = new Editor(doc);
+        String result = editor.toXml();
         assertTrue(result.startsWith("<?xml version=\"1.0\"?>\n<!DOCTYPE project>\n"));
         assertTrue(result.contains("<name>modified</name>"));
     }

--- a/core/src/test/java/eu/maveniverse/domtrip/DoctypePreservationTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/DoctypePreservationTest.java
@@ -164,6 +164,30 @@ class DoctypePreservationTest {
     }
 
     @Test
+    void testWhitespaceBetweenXmlDeclarationAndDoctype() throws DomTripException {
+        String xml = "<?xml version=\"1.0\"?>\n<!DOCTYPE root>\n<root/>";
+        Document doc = Document.of(xml);
+        Editor editor = new Editor(doc);
+        String result = editor.toXml();
+        assertEquals(xml, result);
+    }
+
+    @Test
+    void testWhitespaceBetweenXmlDeclarationAndDoctypeAfterModification() throws DomTripException {
+        String xml = "<?xml version=\"1.0\"?>\n<!DOCTYPE project>\n<project><name>test</name></project>";
+        Document doc = Document.of(xml);
+
+        // Modify the document
+        Element root = doc.root();
+        Element name = root.childElement("name").orElseThrow();
+        name.textContent("modified");
+
+        String result = doc.toXml();
+        assertTrue(result.startsWith("<?xml version=\"1.0\"?>\n<!DOCTYPE project>\n"));
+        assertTrue(result.contains("<name>modified</name>"));
+    }
+
+    @Test
     void testLosslessRoundTrip() throws DomTripException {
         String originalXml = """
             <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- Fixes whitespace between XML declaration and DOCTYPE being stripped during round-trip parsing (#190)
- The parser was marking documents as modified during parsing by using public setters that call `markModified()`, causing the Serializer to bypass the fast-path `toXml()` and use a manual reconstruction path that omitted `doctypePrecedingWhitespace`
- Adds internal (package-private) setters for Document fields set during parsing, following the existing `*Internal` pattern
- Fixes the Serializer fallback path to include `doctypePrecedingWhitespace` when emitting DOCTYPE

## Test plan

- [x] Added `testWhitespaceBetweenXmlDeclarationAndDoctype` - verifies exact round-trip of the reproduction case from #190
- [x] Added `testWhitespaceBetweenXmlDeclarationAndDoctypeAfterModification` - verifies whitespace is preserved even after document modification
- [x] All 1237 existing tests pass
- [x] Full project build succeeds

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parsing and serialization now preserve exact whitespace and the XML declaration/DOCTYPE prefix, improving round‑trip fidelity and preventing unintended layout changes.
  * Document serialization now handles document nodes consistently, avoiding accidental emission of unfiltered content.

* **New Features**
  * Public accessor to retrieve the whitespace that precedes the DOCTYPE.

* **Tests**
  * Added tests verifying exact preservation of XML-declaration + DOCTYPE spacing, correct round-trips after edits, and serializer behavior (including minimal/pretty modes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->