### PR TITLE
feat: add XML-aware structural diff

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/ChangeType.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/ChangeType.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+/**
+ * Enumerates the types of changes that can be detected between two XML documents.
+ *
+ * <p>Change types are classified as either <em>semantic</em> (affecting the meaning
+ * of the XML) or <em>formatting-only</em> (affecting only the presentation). This
+ * classification enables filtering to focus on meaningful changes while ignoring
+ * formatting noise.</p>
+ *
+ * @see XmlChange
+ * @see XmlDiff
+ * @since 1.3.0
+ */
+public enum ChangeType {
+
+    /** A new element was inserted. */
+    ELEMENT_ADDED,
+
+    /** An element was deleted. */
+    ELEMENT_REMOVED,
+
+    /** An element was reordered among its siblings (same content, different position). */
+    ELEMENT_MOVED,
+
+    /** Text content of an element was modified. */
+    TEXT_CHANGED,
+
+    /** A new attribute was added to an existing element. */
+    ATTRIBUTE_ADDED,
+
+    /** An attribute was removed from an element. */
+    ATTRIBUTE_REMOVED,
+
+    /** An attribute value was modified. */
+    ATTRIBUTE_CHANGED,
+
+    /** A comment was inserted. */
+    COMMENT_ADDED,
+
+    /** A comment was deleted. */
+    COMMENT_REMOVED,
+
+    /** Comment content was modified. */
+    COMMENT_CHANGED,
+
+    /** A namespace declaration was modified. */
+    NAMESPACE_CHANGED,
+
+    /** Indentation or spacing changed (formatting only, no semantic effect). */
+    WHITESPACE_CHANGED,
+
+    /** Attribute quote style changed between single and double (formatting only). */
+    QUOTE_STYLE_CHANGED,
+
+    /** Entity encoding form changed, e.g. {@code &lt;} vs {@code &#60;} (formatting only). */
+    ENTITY_FORM_CHANGED,
+
+    /** Empty element style changed between self-closing and expanded (formatting only). */
+    EMPTY_ELEMENT_STYLE_CHANGED;
+
+    /**
+     * Returns whether this change type represents a semantic change that affects
+     * the meaning of the XML document.
+     *
+     * @return {@code true} if the change is semantic, {@code false} if formatting-only
+     */
+    public boolean isSemantic() {
+        switch (this) {
+            case WHITESPACE_CHANGED:
+            case QUOTE_STYLE_CHANGED:
+            case ENTITY_FORM_CHANGED:
+            case EMPTY_ELEMENT_STYLE_CHANGED:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    /**
+     * Returns whether this change type represents a formatting-only change that
+     * does not affect the semantic meaning of the XML document.
+     *
+     * @return {@code true} if the change is formatting-only, {@code false} if semantic
+     */
+    public boolean isFormattingOnly() {
+        return !isSemantic();
+    }
+}

--- a/core/src/main/java/eu/maveniverse/domtrip/DiffConfig.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DiffConfig.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Configuration for XML diff operations.
+ *
+ * <p>Controls how elements are matched between two documents. By default, elements
+ * are matched positionally among same-name siblings. Configuring match keys enables
+ * identity-based matching for domain-specific element types.</p>
+ *
+ * <h3>Example:</h3>
+ * <pre>{@code
+ * DiffConfig config = DiffConfig.builder()
+ *     .matchBy("dependency", "groupId", "artifactId")
+ *     .matchBy("*", "id")
+ *     .orderSensitive("modules/module")
+ *     .build();
+ * }</pre>
+ *
+ * @see XmlDiff
+ * @since 1.3.0
+ */
+public class DiffConfig {
+
+    private final Map<String, List<String>> matchKeys;
+    private final List<String> wildcardMatchKeys;
+    private final Set<String> orderSensitivePaths;
+
+    private DiffConfig(
+            Map<String, List<String>> matchKeys, List<String> wildcardMatchKeys, Set<String> orderSensitivePaths) {
+        this.matchKeys = Collections.unmodifiableMap(new LinkedHashMap<>(matchKeys));
+        this.wildcardMatchKeys = wildcardMatchKeys.isEmpty()
+                ? Collections.<String>emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(wildcardMatchKeys));
+        this.orderSensitivePaths = orderSensitivePaths.isEmpty()
+                ? Collections.<String>emptySet()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(orderSensitivePaths));
+    }
+
+    /**
+     * Returns a default configuration with no match keys.
+     *
+     * @return the default configuration
+     */
+    public static DiffConfig defaults() {
+        return new DiffConfig(
+                Collections.<String, List<String>>emptyMap(),
+                Collections.<String>emptyList(),
+                Collections.<String>emptySet());
+    }
+
+    /**
+     * Returns a new builder for constructing a custom configuration.
+     *
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Returns the match key attribute or child element names for the given element name,
+     * falling back to wildcard keys if no specific keys are configured.
+     *
+     * @param elementName the element name to look up
+     * @return the list of key names, or an empty list if none configured
+     */
+    public List<String> matchKeysFor(String elementName) {
+        List<String> keys = matchKeys.get(elementName);
+        if (keys != null) {
+            return keys;
+        }
+        return wildcardMatchKeys;
+    }
+
+    /**
+     * Returns whether the given path should use order-sensitive comparison.
+     *
+     * @param path the path to check
+     * @return {@code true} if order-sensitive
+     */
+    public boolean isOrderSensitive(String path) {
+        return orderSensitivePaths.contains(path);
+    }
+
+    /**
+     * Builder for {@link DiffConfig}.
+     */
+    public static class Builder {
+
+        private final Map<String, List<String>> matchKeys = new LinkedHashMap<>();
+        private final List<String> wildcardMatchKeys = new ArrayList<>();
+        private final Set<String> orderSensitivePaths = new LinkedHashSet<>();
+
+        /**
+         * Configures match keys for an element name. Use {@code "*"} as the element
+         * name for a wildcard that applies to all elements without specific keys.
+         *
+         * <p>Keys can refer to child element names (e.g., {@code "groupId"} for Maven
+         * dependencies) or attribute names (e.g., {@code "id"}).</p>
+         *
+         * @param elementName the element name, or {@code "*"} for wildcard
+         * @param keyAttributes the attribute or child element names that form the identity
+         * @return this builder
+         */
+        public Builder matchBy(String elementName, String... keyAttributes) {
+            if ("*".equals(elementName)) {
+                wildcardMatchKeys.addAll(Arrays.asList(keyAttributes));
+            } else {
+                matchKeys.put(elementName, Arrays.asList(keyAttributes));
+            }
+            return this;
+        }
+
+        /**
+         * Marks a path as order-sensitive, meaning element reordering under this
+         * path will be detected as moves.
+         *
+         * @param path the path to mark as order-sensitive
+         * @return this builder
+         */
+        public Builder orderSensitive(String path) {
+            orderSensitivePaths.add(path);
+            return this;
+        }
+
+        /**
+         * Builds the configuration.
+         *
+         * @return the built configuration
+         */
+        public DiffConfig build() {
+            return new DiffConfig(matchKeys, wildcardMatchKeys, orderSensitivePaths);
+        }
+    }
+}

--- a/core/src/main/java/eu/maveniverse/domtrip/DiffResult.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DiffResult.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The result of comparing two XML documents, containing all detected changes.
+ *
+ * <p>Provides methods to filter changes by type (semantic vs. formatting-only)
+ * or by path, and to check whether any changes were detected.</p>
+ *
+ * <h3>Example:</h3>
+ * <pre>{@code
+ * DiffResult diff = XmlDiff.diff(before, after);
+ *
+ * // Semantic changes only (ignore whitespace/formatting)
+ * List<XmlChange> semantic = diff.semanticChanges();
+ *
+ * // Formatting-only changes
+ * List<XmlChange> formatting = diff.formattingChanges();
+ *
+ * // Changes at a specific path
+ * List<XmlChange> depChanges = diff.changesUnder("/project/dependencies");
+ * }</pre>
+ *
+ * @see XmlDiff
+ * @see XmlChange
+ * @since 1.3.0
+ */
+public class DiffResult {
+
+    private final List<XmlChange> changes;
+
+    /**
+     * Creates a new DiffResult with the given changes.
+     *
+     * @param changes the list of changes
+     */
+    public DiffResult(List<XmlChange> changes) {
+        this.changes = Collections.unmodifiableList(new ArrayList<>(changes));
+    }
+
+    /**
+     * Returns all changes.
+     *
+     * @return an unmodifiable list of all changes
+     */
+    public List<XmlChange> changes() {
+        return changes;
+    }
+
+    /**
+     * Returns only semantic changes that affect the meaning of the XML.
+     *
+     * @return the list of semantic changes
+     */
+    public List<XmlChange> semanticChanges() {
+        return changes.stream().filter(XmlChange::isSemantic).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns only formatting changes that do not affect meaning.
+     *
+     * @return the list of formatting-only changes
+     */
+    public List<XmlChange> formattingChanges() {
+        return changes.stream().filter(XmlChange::isFormattingOnly).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns changes under the specified path prefix.
+     *
+     * @param path the path prefix to filter by
+     * @return the list of changes under the given path
+     */
+    public List<XmlChange> changesUnder(String path) {
+        return changes.stream().filter(c -> c.path().startsWith(path)).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns {@code true} if any changes were detected.
+     *
+     * @return {@code true} if there are changes
+     */
+    public boolean hasChanges() {
+        return !changes.isEmpty();
+    }
+
+    /**
+     * Returns changes affecting elements that match the given XPath expression
+     * in the specified document. This enables rich filtering like
+     * {@code diff.changesFor("//dependency[scope='test']", afterDoc)}.
+     *
+     * @param xpath the XPath expression to match elements
+     * @param doc the document to evaluate the expression against
+     * @return the list of changes at or under matching elements
+     * @since 1.3.0
+     */
+    public List<XmlChange> changesFor(String xpath, Document doc) {
+        return changesFor(XPathExpression.compile(xpath), doc);
+    }
+
+    /**
+     * Returns changes affecting elements that match the given compiled XPath expression
+     * in the specified document.
+     *
+     * @param xpath the compiled XPath expression to match elements
+     * @param doc the document to evaluate the expression against
+     * @return the list of changes at or under matching elements
+     * @since 1.3.0
+     */
+    public List<XmlChange> changesFor(XPathExpression xpath, Document doc) {
+        Element root = doc.root();
+        if (root == null) {
+            return Collections.emptyList();
+        }
+        List<Element> matched = xpath.select(root);
+        if (matched.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Set<String> matchedPaths =
+                matched.stream().map(DiffResult::computeElementPath).collect(Collectors.toSet());
+        return changes.stream()
+                .filter(c -> matchedPaths.stream().anyMatch(p -> c.path().startsWith(p)))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns {@code true} if any semantic changes were detected.
+     *
+     * @return {@code true} if there are semantic changes
+     */
+    public boolean hasSemanticChanges() {
+        return changes.stream().anyMatch(XmlChange::isSemantic);
+    }
+
+    /**
+     * Returns {@code true} if any formatting changes were detected.
+     *
+     * @return {@code true} if there are formatting-only changes
+     */
+    public boolean hasFormattingChanges() {
+        return changes.stream().anyMatch(XmlChange::isFormattingOnly);
+    }
+
+    @Override
+    public String toString() {
+        if (changes.isEmpty()) {
+            return "No changes";
+        }
+        return changes.stream().map(XmlChange::toString).collect(Collectors.joining("\n"));
+    }
+
+    /** Computes the XPath-like path for an element by walking up the parent chain. */
+    static String computeElementPath(Element element) {
+        List<String> parts = new ArrayList<>();
+        Element current = element;
+        while (current != null) {
+            parts.add(computePathStep(current));
+            ContainerNode parent = current.parent();
+            current = (parent instanceof Element) ? (Element) parent : null;
+        }
+        Collections.reverse(parts);
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            sb.append('/').append(part);
+        }
+        return sb.toString();
+    }
+
+    /** Computes a single path step, adding a positional index when multiple same-name siblings exist. */
+    private static String computePathStep(Element element) {
+        String name = element.name();
+        ContainerNode parent = element.parent();
+        if (!(parent instanceof Element)) {
+            return name;
+        }
+        List<Element> siblings = ((Element) parent).childElements().collect(Collectors.toList());
+        long sameNameCount =
+                siblings.stream().filter(e -> e.name().equals(name)).count();
+        if (sameNameCount <= 1) {
+            return name;
+        }
+        int pos = 1;
+        for (Element sibling : siblings) {
+            if (sibling == element) {
+                break;
+            }
+            if (sibling.name().equals(name)) {
+                pos++;
+            }
+        }
+        return name + "[" + pos + "]";
+    }
+}

--- a/core/src/main/java/eu/maveniverse/domtrip/XmlChange.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/XmlChange.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import java.util.Objects;
+
+/**
+ * Represents a single change detected between two XML documents.
+ *
+ * <p>Each change has a {@link ChangeType type}, an XPath-like {@link #path() path}
+ * identifying the location, and optional before/after values and node references.</p>
+ *
+ * <h3>Example output:</h3>
+ * <pre>
+ * ELEMENT_ADDED: /project/dependencies/dependency[3]
+ * TEXT_CHANGED: /project/version: "1.0" &rarr; "1.1"
+ * ATTRIBUTE_CHANGED: /project/dependencies/dependency[2]/@scope: "compile" &rarr; "test"
+ * </pre>
+ *
+ * @see ChangeType
+ * @see DiffResult
+ * @see XmlDiff
+ * @since 1.3.0
+ */
+public class XmlChange {
+
+    private final ChangeType type;
+    private final String path;
+    private final String beforeValue;
+    private final String afterValue;
+    private final Node beforeNode;
+    private final Node afterNode;
+
+    /**
+     * Creates a new XmlChange.
+     *
+     * @param type the type of change
+     * @param path the XPath-like path to the changed node
+     * @param beforeValue the value before the change, or {@code null} for additions
+     * @param afterValue the value after the change, or {@code null} for removals
+     * @param beforeNode the node before the change, or {@code null} for additions
+     * @param afterNode the node after the change, or {@code null} for removals
+     */
+    public XmlChange(
+            ChangeType type, String path, String beforeValue, String afterValue, Node beforeNode, Node afterNode) {
+        this.type = Objects.requireNonNull(type, "type");
+        this.path = Objects.requireNonNull(path, "path");
+        this.beforeValue = beforeValue;
+        this.afterValue = afterValue;
+        this.beforeNode = beforeNode;
+        this.afterNode = afterNode;
+    }
+
+    /**
+     * Returns the type of change.
+     *
+     * @return the change type
+     */
+    public ChangeType type() {
+        return type;
+    }
+
+    /**
+     * Returns the XPath-like path to the changed node.
+     *
+     * @return the path
+     */
+    public String path() {
+        return path;
+    }
+
+    /**
+     * Returns {@code true} if the change affects the semantic meaning of the XML.
+     *
+     * @return {@code true} if semantic
+     */
+    public boolean isSemantic() {
+        return type.isSemantic();
+    }
+
+    /**
+     * Returns {@code true} if the change is formatting-only (no semantic effect).
+     *
+     * @return {@code true} if formatting-only
+     */
+    public boolean isFormattingOnly() {
+        return type.isFormattingOnly();
+    }
+
+    /**
+     * Returns the value before the change, or {@code null} for additions.
+     *
+     * @return the before value
+     */
+    public String beforeValue() {
+        return beforeValue;
+    }
+
+    /**
+     * Returns the value after the change, or {@code null} for removals.
+     *
+     * @return the after value
+     */
+    public String afterValue() {
+        return afterValue;
+    }
+
+    /**
+     * Returns the node before the change, or {@code null} for additions.
+     *
+     * @return the before node
+     */
+    public Node beforeNode() {
+        return beforeNode;
+    }
+
+    /**
+     * Returns the node after the change, or {@code null} for removals.
+     *
+     * @return the after node
+     */
+    public Node afterNode() {
+        return afterNode;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(type).append(": ").append(path);
+        if (beforeValue != null && afterValue != null) {
+            sb.append(": \"")
+                    .append(beforeValue)
+                    .append("\" \u2192 \"")
+                    .append(afterValue)
+                    .append("\"");
+        } else if (afterValue != null) {
+            sb.append(": \"").append(afterValue).append("\"");
+        } else if (beforeValue != null) {
+            sb.append(": \"").append(beforeValue).append("\"");
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        XmlChange that = (XmlChange) o;
+        return type == that.type
+                && Objects.equals(path, that.path)
+                && Objects.equals(beforeValue, that.beforeValue)
+                && Objects.equals(afterValue, that.afterValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, path, beforeValue, afterValue);
+    }
+}

--- a/core/src/main/java/eu/maveniverse/domtrip/XmlDiff.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/XmlDiff.java
@@ -1,0 +1,617 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * XML-aware structural diff engine that compares two documents and detects
+ * both semantic and formatting-only changes.
+ *
+ * <p>Because DomTrip preserves all formatting metadata (whitespace, quote styles,
+ * entity encoding, empty element style), this diff can uniquely distinguish
+ * between changes that affect meaning and changes that are formatting-only.
+ * This is a capability no other Java XML library offers.</p>
+ *
+ * <h3>Basic usage:</h3>
+ * <pre>{@code
+ * Document before = Document.of(oldXml);
+ * Document after = Document.of(newXml);
+ *
+ * DiffResult diff = XmlDiff.diff(before, after);
+ *
+ * for (XmlChange change : diff.changes()) {
+ *     System.out.println(change);
+ * }
+ * // → ELEMENT_ADDED: /project/dependencies/dependency[3]
+ * // → TEXT_CHANGED: /project/version: "1.0" → "1.1"
+ * // → ATTRIBUTE_CHANGED: /project/dependencies/dependency[2]/@scope: "compile" → "test"
+ * }</pre>
+ *
+ * <h3>Configurable matching:</h3>
+ * <pre>{@code
+ * DiffConfig config = DiffConfig.builder()
+ *     .matchBy("dependency", "groupId", "artifactId")
+ *     .build();
+ *
+ * DiffResult diff = XmlDiff.diff(before, after, config);
+ * }</pre>
+ *
+ * @see DiffResult
+ * @see DiffConfig
+ * @see XmlChange
+ * @see ChangeType
+ * @since 1.3.0
+ */
+public final class XmlDiff {
+
+    private XmlDiff() {}
+
+    /**
+     * Compares two documents using default configuration (positional matching).
+     *
+     * @param before the original document
+     * @param after the modified document
+     * @return the diff result containing all detected changes
+     */
+    public static DiffResult diff(Document before, Document after) {
+        return diff(before, after, DiffConfig.defaults());
+    }
+
+    /**
+     * Compares two documents using the given configuration.
+     *
+     * @param before the original document
+     * @param after the modified document
+     * @param config the diff configuration controlling element matching
+     * @return the diff result containing all detected changes
+     */
+    public static DiffResult diff(Document before, Document after, DiffConfig config) {
+        Objects.requireNonNull(before, "before");
+        Objects.requireNonNull(after, "after");
+        Objects.requireNonNull(config, "config");
+
+        List<XmlChange> changes = new ArrayList<>();
+        Element beforeRoot = before.root();
+        Element afterRoot = after.root();
+
+        if (beforeRoot == null && afterRoot == null) {
+            return new DiffResult(changes);
+        }
+        if (beforeRoot == null) {
+            addElementAdded(changes, "/" + afterRoot.name(), afterRoot);
+            return new DiffResult(changes);
+        }
+        if (afterRoot == null) {
+            addElementRemoved(changes, "/" + beforeRoot.name(), beforeRoot);
+            return new DiffResult(changes);
+        }
+
+        if (!beforeRoot.name().equals(afterRoot.name())) {
+            addElementRemoved(changes, "/" + beforeRoot.name(), beforeRoot);
+            addElementAdded(changes, "/" + afterRoot.name(), afterRoot);
+        } else {
+            compareElements(beforeRoot, afterRoot, "/" + beforeRoot.name(), config, changes);
+        }
+
+        return new DiffResult(changes);
+    }
+
+    // --- Element comparison ---
+
+    private static void compareElements(
+            Element before, Element after, String path, DiffConfig config, List<XmlChange> changes) {
+        compareElementFormatting(before, after, path, changes);
+        compareNamespace(before, after, path, changes);
+        compareAttributes(before, after, path, changes);
+        compareTextContent(before, after, path, changes);
+        compareComments(before, after, path, changes);
+        compareChildElements(before, after, path, config, changes);
+    }
+
+    private static void compareElementFormatting(Element before, Element after, String path, List<XmlChange> changes) {
+        if (!safeEquals(before.precedingWhitespace(), after.precedingWhitespace())
+                || !safeEquals(before.openTagWhitespace(), after.openTagWhitespace())
+                || !safeEquals(before.innerPrecedingWhitespace(), after.innerPrecedingWhitespace())
+                || !safeEquals(before.closeTagWhitespace(), after.closeTagWhitespace())) {
+            changes.add(new XmlChange(ChangeType.WHITESPACE_CHANGED, path, null, null, before, after));
+        }
+
+        if (before.selfClosing() != after.selfClosing() && before.isEmpty() && after.isEmpty()) {
+            changes.add(new XmlChange(
+                    ChangeType.EMPTY_ELEMENT_STYLE_CHANGED,
+                    path,
+                    before.selfClosing() ? "self-closing" : "expanded",
+                    after.selfClosing() ? "self-closing" : "expanded",
+                    before,
+                    after));
+        }
+    }
+
+    private static void compareNamespace(Element before, Element after, String path, List<XmlChange> changes) {
+        String beforeNs = before.namespaceURI();
+        String afterNs = after.namespaceURI();
+        if (!safeEquals(beforeNs, afterNs)) {
+            changes.add(new XmlChange(ChangeType.NAMESPACE_CHANGED, path, beforeNs, afterNs, before, after));
+        }
+    }
+
+    // --- Attribute comparison ---
+
+    private static void compareAttributes(Element before, Element after, String path, List<XmlChange> changes) {
+        Map<String, Attribute> beforeAttrs = before.attributeObjects();
+        Map<String, Attribute> afterAttrs = after.attributeObjects();
+
+        for (Map.Entry<String, Attribute> entry : beforeAttrs.entrySet()) {
+            String name = entry.getKey();
+            Attribute beforeAttr = entry.getValue();
+            Attribute afterAttr = afterAttrs.get(name);
+            String attrPath = path + "/@" + name;
+
+            if (afterAttr == null) {
+                changes.add(
+                        new XmlChange(ChangeType.ATTRIBUTE_REMOVED, attrPath, beforeAttr.value(), null, before, after));
+            } else {
+                compareAttributeValues(beforeAttr, afterAttr, attrPath, before, after, changes);
+            }
+        }
+
+        for (Map.Entry<String, Attribute> entry : afterAttrs.entrySet()) {
+            if (!beforeAttrs.containsKey(entry.getKey())) {
+                String attrPath = path + "/@" + entry.getKey();
+                changes.add(new XmlChange(
+                        ChangeType.ATTRIBUTE_ADDED,
+                        attrPath,
+                        null,
+                        entry.getValue().value(),
+                        before,
+                        after));
+            }
+        }
+    }
+
+    private static void compareAttributeValues(
+            Attribute before,
+            Attribute after,
+            String attrPath,
+            Element beforeParent,
+            Element afterParent,
+            List<XmlChange> changes) {
+        // Semantic: compare decoded values
+        if (!Objects.equals(before.value(), after.value())) {
+            changes.add(new XmlChange(
+                    ChangeType.ATTRIBUTE_CHANGED, attrPath, before.value(), after.value(), beforeParent, afterParent));
+            return;
+        }
+
+        // Formatting: compare quote style
+        if (before.quoteStyle() != after.quoteStyle()) {
+            changes.add(new XmlChange(
+                    ChangeType.QUOTE_STYLE_CHANGED,
+                    attrPath,
+                    before.quoteStyle().name(),
+                    after.quoteStyle().name(),
+                    beforeParent,
+                    afterParent));
+        }
+
+        // Formatting: compare raw value (entity encoding form)
+        if (before.rawValue() != null && after.rawValue() != null && !safeEquals(before.rawValue(), after.rawValue())) {
+            changes.add(new XmlChange(
+                    ChangeType.ENTITY_FORM_CHANGED,
+                    attrPath,
+                    before.rawValue(),
+                    after.rawValue(),
+                    beforeParent,
+                    afterParent));
+        }
+
+        // Formatting: compare attribute whitespace
+        if (!safeEquals(before.precedingWhitespace(), after.precedingWhitespace())) {
+            changes.add(new XmlChange(
+                    ChangeType.WHITESPACE_CHANGED,
+                    attrPath,
+                    before.precedingWhitespace(),
+                    after.precedingWhitespace(),
+                    beforeParent,
+                    afterParent));
+        }
+    }
+
+    // --- Text comparison ---
+
+    private static void compareTextContent(Element before, Element after, String path, List<XmlChange> changes) {
+        List<Text> beforeTexts = getTextNodes(before);
+        List<Text> afterTexts = getTextNodes(after);
+
+        String beforeContent = joinTextContent(beforeTexts);
+        String afterContent = joinTextContent(afterTexts);
+
+        if (!beforeContent.equals(afterContent)) {
+            changes.add(new XmlChange(ChangeType.TEXT_CHANGED, path, beforeContent, afterContent, before, after));
+        } else if (!beforeContent.isEmpty()) {
+            // Same decoded content — check raw formatting (entity encoding)
+            String beforeRaw = joinRawContent(beforeTexts);
+            String afterRaw = joinRawContent(afterTexts);
+            if (!beforeRaw.equals(afterRaw)) {
+                changes.add(new XmlChange(ChangeType.ENTITY_FORM_CHANGED, path, beforeRaw, afterRaw, before, after));
+            }
+        }
+    }
+
+    // --- Comment comparison ---
+
+    private static void compareComments(Element before, Element after, String path, List<XmlChange> changes) {
+        List<Comment> beforeComments = getComments(before);
+        List<Comment> afterComments = getComments(after);
+
+        int matchCount = Math.min(beforeComments.size(), afterComments.size());
+        boolean needsIndex = beforeComments.size() > 1 || afterComments.size() > 1;
+
+        for (int i = 0; i < matchCount; i++) {
+            Comment bc = beforeComments.get(i);
+            Comment ac = afterComments.get(i);
+            if (!Objects.equals(bc.content(), ac.content())) {
+                changes.add(new XmlChange(
+                        ChangeType.COMMENT_CHANGED,
+                        commentPath(path, i, needsIndex),
+                        bc.content(),
+                        ac.content(),
+                        bc,
+                        ac));
+            }
+        }
+
+        for (int i = matchCount; i < beforeComments.size(); i++) {
+            changes.add(new XmlChange(
+                    ChangeType.COMMENT_REMOVED,
+                    commentPath(path, i, needsIndex),
+                    beforeComments.get(i).content(),
+                    null,
+                    beforeComments.get(i),
+                    null));
+        }
+
+        for (int i = matchCount; i < afterComments.size(); i++) {
+            changes.add(new XmlChange(
+                    ChangeType.COMMENT_ADDED,
+                    commentPath(path, i, needsIndex),
+                    null,
+                    afterComments.get(i).content(),
+                    null,
+                    afterComments.get(i)));
+        }
+    }
+
+    /** Builds an XPath-like comment path, adding a positional index when multiple comments exist. */
+    private static String commentPath(String path, int index, boolean needsIndex) {
+        return needsIndex ? path + "/comment()[" + (index + 1) + "]" : path + "/comment()";
+    }
+
+    // --- Child element comparison ---
+
+    private static void compareChildElements(
+            Element before, Element after, String path, DiffConfig config, List<XmlChange> changes) {
+        List<Element> beforeChildren = before.childElements().collect(Collectors.toList());
+        List<Element> afterChildren = after.childElements().collect(Collectors.toList());
+
+        if (beforeChildren.isEmpty() && afterChildren.isEmpty()) {
+            return;
+        }
+
+        MatchResult match = matchChildren(beforeChildren, afterChildren, config);
+
+        // Report removed elements
+        for (int idx : match.removed) {
+            Element elem = beforeChildren.get(idx);
+            String childPath = computeChildPath(path, elem.name(), beforeChildren, idx);
+            addElementRemoved(changes, childPath, elem);
+        }
+
+        // Report added elements
+        for (int idx : match.added) {
+            Element elem = afterChildren.get(idx);
+            String childPath = computeChildPath(path, elem.name(), afterChildren, idx);
+            addElementAdded(changes, childPath, elem);
+        }
+
+        // Process matched elements — detect moves and recurse
+        for (int[] pair : match.matched) {
+            Element beforeChild = beforeChildren.get(pair[0]);
+            Element afterChild = afterChildren.get(pair[1]);
+            String childPath = computeChildPath(path, beforeChild.name(), beforeChildren, pair[0]);
+
+            // Detect moves (only for key-matched elements where position changed)
+            if (pair[2] == 1) {
+                int beforePos = sameNamePosition(beforeChildren, pair[0], match.matchedBeforeSet);
+                int afterPos = sameNamePosition(afterChildren, pair[1], match.matchedAfterSet);
+                if (beforePos != afterPos) {
+                    changes.add(new XmlChange(
+                            ChangeType.ELEMENT_MOVED,
+                            childPath,
+                            String.valueOf(beforePos + 1),
+                            String.valueOf(afterPos + 1),
+                            beforeChild,
+                            afterChild));
+                }
+            }
+
+            compareElements(beforeChild, afterChild, childPath, config, changes);
+        }
+    }
+
+    // --- Child matching algorithm ---
+
+    /**
+     * Two-phase child matching: first by configured identity keys, then positionally by name.
+     * Each matched entry is {@code int[]{beforeIdx, afterIdx, matchType}} where matchType
+     * 1 = key-matched, 0 = positional.
+     */
+    private static MatchResult matchChildren(
+            List<Element> beforeChildren, List<Element> afterChildren, DiffConfig config) {
+        Set<Integer> matchedBefore = new LinkedHashSet<>();
+        Set<Integer> matchedAfter = new LinkedHashSet<>();
+        List<int[]> matched = new ArrayList<>();
+
+        matchByKeys(beforeChildren, afterChildren, config, matchedBefore, matchedAfter, matched);
+        matchByPosition(beforeChildren, afterChildren, matchedBefore, matchedAfter, matched);
+
+        List<Integer> removed = collectUnmatched(beforeChildren.size(), matchedBefore);
+        List<Integer> added = collectUnmatched(afterChildren.size(), matchedAfter);
+
+        return new MatchResult(matched, removed, added, matchedBefore, matchedAfter);
+    }
+
+    /** Phase 1: matches children by configured identity keys (e.g., groupId+artifactId for dependencies). */
+    private static void matchByKeys(
+            List<Element> beforeChildren,
+            List<Element> afterChildren,
+            DiffConfig config,
+            Set<Integer> matchedBefore,
+            Set<Integer> matchedAfter,
+            List<int[]> matched) {
+        for (int i = 0; i < beforeChildren.size(); i++) {
+            if (matchedBefore.contains(i)) {
+                // already matched — skip
+            } else {
+                tryKeyMatch(beforeChildren.get(i), i, afterChildren, config, matchedBefore, matchedAfter, matched);
+            }
+        }
+    }
+
+    /** Attempts to find a key-based match for a single before-child in the after-children list. */
+    private static void tryKeyMatch(
+            Element bc,
+            int beforeIndex,
+            List<Element> afterChildren,
+            DiffConfig config,
+            Set<Integer> matchedBefore,
+            Set<Integer> matchedAfter,
+            List<int[]> matched) {
+        List<String> keys = config.matchKeysFor(bc.name());
+        if (keys.isEmpty()) {
+            return;
+        }
+        String keySignature = computeKeySignature(bc, keys);
+        if (keySignature == null) {
+            return;
+        }
+        int match = findKeyMatch(afterChildren, bc.name(), keySignature, keys, matchedAfter);
+        if (match >= 0) {
+            matched.add(new int[] {beforeIndex, match, 1}); // 1 = key-matched
+            matchedBefore.add(beforeIndex);
+            matchedAfter.add(match);
+        }
+    }
+
+    /** Returns the index of the first unmatched after-child with the same name and key signature, or -1. */
+    private static int findKeyMatch(
+            List<Element> afterChildren,
+            String name,
+            String keySignature,
+            List<String> keys,
+            Set<Integer> matchedAfter) {
+        for (int j = 0; j < afterChildren.size(); j++) {
+            if (!matchedAfter.contains(j) && name.equals(afterChildren.get(j).name())) {
+                String afterSig = computeKeySignature(afterChildren.get(j), keys);
+                if (keySignature.equals(afterSig)) {
+                    return j;
+                }
+            }
+        }
+        return -1;
+    }
+
+    /** Phase 2: matches remaining unmatched children positionally among same-name siblings. */
+    private static void matchByPosition(
+            List<Element> beforeChildren,
+            List<Element> afterChildren,
+            Set<Integer> matchedBefore,
+            Set<Integer> matchedAfter,
+            List<int[]> matched) {
+        Map<String, List<Integer>> remainingBefore = groupByName(beforeChildren, matchedBefore);
+        Map<String, List<Integer>> remainingAfter = groupByName(afterChildren, matchedAfter);
+
+        for (Map.Entry<String, List<Integer>> entry : remainingBefore.entrySet()) {
+            List<Integer> beforeIndices = entry.getValue();
+            List<Integer> afterIndices = remainingAfter.getOrDefault(entry.getKey(), Collections.<Integer>emptyList());
+
+            int matchCount = Math.min(beforeIndices.size(), afterIndices.size());
+            for (int k = 0; k < matchCount; k++) {
+                matched.add(new int[] {beforeIndices.get(k), afterIndices.get(k), 0}); // 0 = positional
+                matchedBefore.add(beforeIndices.get(k));
+                matchedAfter.add(afterIndices.get(k));
+            }
+        }
+    }
+
+    private static List<Integer> collectUnmatched(int size, Set<Integer> matched) {
+        List<Integer> unmatched = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            if (!matched.contains(i)) {
+                unmatched.add(i);
+            }
+        }
+        return unmatched;
+    }
+
+    /** Builds an identity signature from child elements or attributes named by the keys, or null if any key is missing. */
+    private static String computeKeySignature(Element element, List<String> keys) {
+        StringBuilder sb = new StringBuilder();
+        for (String key : keys) {
+            // Try child element first (Maven-style keys like groupId)
+            Optional<Element> keyChild = element.childElement(key);
+            if (keyChild.isPresent()) {
+                sb.append(key).append('=').append(keyChild.get().textContent()).append(';');
+            } else {
+                // Fall back to attribute
+                String attrValue = element.attribute(key);
+                if (attrValue != null) {
+                    sb.append(key).append('=').append(attrValue).append(';');
+                } else {
+                    return null; // Key not found
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private static Map<String, List<Integer>> groupByName(List<Element> elements, Set<Integer> excluded) {
+        Map<String, List<Integer>> grouped = new LinkedHashMap<>();
+        for (int i = 0; i < elements.size(); i++) {
+            if (excluded.contains(i)) {
+                continue;
+            }
+            grouped.computeIfAbsent(elements.get(i).name(), k -> new ArrayList<>())
+                    .add(i);
+        }
+        return grouped;
+    }
+
+    /**
+     * Computes the 0-based position of an element among matched same-name siblings.
+     */
+    private static int sameNamePosition(List<Element> children, int index, Set<Integer> matchedIndices) {
+        String name = children.get(index).name();
+        int pos = 0;
+        for (int i = 0; i < index; i++) {
+            if (matchedIndices.contains(i) && children.get(i).name().equals(name)) {
+                pos++;
+            }
+        }
+        return pos;
+    }
+
+    // --- Path helpers ---
+
+    private static String computeChildPath(String parentPath, String name, List<Element> siblings, int index) {
+        long sameNameCount =
+                siblings.stream().filter(e -> e.name().equals(name)).count();
+        if (sameNameCount > 1) {
+            int pos = 1;
+            for (int i = 0; i < index; i++) {
+                if (siblings.get(i).name().equals(name)) {
+                    pos++;
+                }
+            }
+            return parentPath + "/" + name + "[" + pos + "]";
+        }
+        return parentPath + "/" + name;
+    }
+
+    // --- Node collection helpers ---
+
+    private static List<Text> getTextNodes(Element element) {
+        return element.children()
+                .filter(Text.class::isInstance)
+                .map(Text.class::cast)
+                .collect(Collectors.toList());
+    }
+
+    private static List<Comment> getComments(Element element) {
+        return element.children()
+                .filter(Comment.class::isInstance)
+                .map(Comment.class::cast)
+                .collect(Collectors.toList());
+    }
+
+    private static String joinTextContent(List<Text> texts) {
+        StringBuilder sb = new StringBuilder();
+        for (Text t : texts) {
+            sb.append(t.content());
+        }
+        return sb.toString();
+    }
+
+    private static String joinRawContent(List<Text> texts) {
+        StringBuilder sb = new StringBuilder();
+        for (Text t : texts) {
+            sb.append(t.rawContent() != null ? t.rawContent() : t.content());
+        }
+        return sb.toString();
+    }
+
+    // --- Change creation helpers ---
+
+    private static void addElementAdded(List<XmlChange> changes, String path, Element element) {
+        changes.add(new XmlChange(ChangeType.ELEMENT_ADDED, path, null, elementSummary(element), null, element));
+    }
+
+    private static void addElementRemoved(List<XmlChange> changes, String path, Element element) {
+        changes.add(new XmlChange(ChangeType.ELEMENT_REMOVED, path, elementSummary(element), null, element, null));
+    }
+
+    private static String elementSummary(Element element) {
+        String text = element.textContent();
+        if (text != null && !text.trim().isEmpty()) {
+            return text.trim();
+        }
+        return "<" + element.name() + ">";
+    }
+
+    // --- Utility ---
+
+    private static boolean safeEquals(String a, String b) {
+        String sa = a != null ? a : "";
+        String sb = b != null ? b : "";
+        return sa.equals(sb);
+    }
+
+    /**
+     * Internal result of the child matching algorithm.
+     */
+    static class MatchResult {
+        final List<int[]> matched; // Each entry: [beforeIdx, afterIdx, keyMatched (1=key, 0=positional)]
+        final List<Integer> removed;
+        final List<Integer> added;
+        final Set<Integer> matchedBeforeSet;
+        final Set<Integer> matchedAfterSet;
+
+        MatchResult(
+                List<int[]> matched,
+                List<Integer> removed,
+                List<Integer> added,
+                Set<Integer> matchedBeforeSet,
+                Set<Integer> matchedAfterSet) {
+            this.matched = matched;
+            this.removed = removed;
+            this.added = added;
+            this.matchedBeforeSet = matchedBeforeSet;
+            this.matchedAfterSet = matchedAfterSet;
+        }
+    }
+}

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -1,0 +1,529 @@
+package eu.maveniverse.domtrip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for XML-aware structural diff.
+ */
+class XmlDiffTest {
+
+    @Test
+    void identicalDocumentsProduceEmptyDiff() {
+        String xml = "<project><version>1.0</version></project>";
+        Document before = Document.of(xml);
+        Document after = Document.of(xml);
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertFalse(result.hasChanges());
+        assertTrue(result.changes().isEmpty());
+        assertEquals("No changes", result.toString());
+    }
+
+    @Test
+    void detectsTextChange() {
+        Document before = Document.of("<project><version>1.0</version></project>");
+        Document after = Document.of("<project><version>1.1</version></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertTrue(result.hasChanges());
+        assertTrue(result.hasSemanticChanges());
+        assertChange(result, ChangeType.TEXT_CHANGED, "/project/version", "1.0", "1.1");
+    }
+
+    @Test
+    void detectsAttributeChange() {
+        Document before = Document.of("<dep scope=\"compile\">junit</dep>");
+        Document after = Document.of("<dep scope=\"test\">junit</dep>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ATTRIBUTE_CHANGED, "/dep/@scope", "compile", "test");
+    }
+
+    @Test
+    void detectsAttributeAdded() {
+        Document before = Document.of("<dep>junit</dep>");
+        Document after = Document.of("<dep scope=\"test\">junit</dep>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ATTRIBUTE_ADDED, "/dep/@scope", null, "test");
+    }
+
+    @Test
+    void detectsAttributeRemoved() {
+        Document before = Document.of("<dep scope=\"test\">junit</dep>");
+        Document after = Document.of("<dep>junit</dep>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ATTRIBUTE_REMOVED, "/dep/@scope", "test", null);
+    }
+
+    @Test
+    void detectsElementAdded() {
+        Document before = Document.of("<project><version>1.0</version></project>");
+        Document after = Document.of("<project><version>1.0</version><name>test</name></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ELEMENT_ADDED, "/project/name");
+    }
+
+    @Test
+    void detectsElementRemoved() {
+        Document before = Document.of("<project><version>1.0</version><name>test</name></project>");
+        Document after = Document.of("<project><version>1.0</version></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ELEMENT_REMOVED, "/project/name");
+    }
+
+    @Test
+    void detectsQuoteStyleChange() {
+        Document before = Document.of("<dep scope='test'>junit</dep>");
+        Document after = Document.of("<dep scope=\"test\">junit</dep>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        List<XmlChange> formatting = result.formattingChanges();
+        boolean hasQuoteChange = formatting.stream()
+                .anyMatch(c ->
+                        c.type() == ChangeType.QUOTE_STYLE_CHANGED && c.path().equals("/dep/@scope"));
+        assertTrue(hasQuoteChange, "Expected QUOTE_STYLE_CHANGED for /dep/@scope");
+        assertFalse(result.hasSemanticChanges());
+    }
+
+    @Test
+    void detectsEmptyElementStyleChange() {
+        Document before = Document.of("<project><br/></project>");
+        Document after = Document.of("<project><br></br></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.EMPTY_ELEMENT_STYLE_CHANGED, "/project/br");
+        assertFalse(result.hasSemanticChanges());
+    }
+
+    @Test
+    void detectsCommentAdded() {
+        Document before = Document.of("<project><version>1.0</version></project>");
+        Document after = Document.of("<project><!-- note --><version>1.0</version></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.COMMENT_ADDED, "/project/comment()");
+    }
+
+    @Test
+    void detectsCommentRemoved() {
+        Document before = Document.of("<project><!-- note --><version>1.0</version></project>");
+        Document after = Document.of("<project><version>1.0</version></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.COMMENT_REMOVED, "/project/comment()");
+    }
+
+    @Test
+    void detectsCommentChanged() {
+        Document before = Document.of("<project><!-- old --><version>1.0</version></project>");
+        Document after = Document.of("<project><!-- new --><version>1.0</version></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.COMMENT_CHANGED, "/project/comment()");
+    }
+
+    @Test
+    void detectsNestedChanges() {
+        Document before = Document.of(
+                "<project><dependencies><dependency><version>1.0</version></dependency></dependencies></project>");
+        Document after = Document.of(
+                "<project><dependencies><dependency><version>2.0</version></dependency></dependencies></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.TEXT_CHANGED, "/project/dependencies/dependency/version", "1.0", "2.0");
+    }
+
+    @Test
+    void indexesMultipleSameNameSiblings() {
+        Document before = Document.of("<deps><dep>A</dep><dep>B</dep></deps>");
+        Document after = Document.of("<deps><dep>A</dep><dep>C</dep></deps>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.TEXT_CHANGED, "/deps/dep[2]", "B", "C");
+    }
+
+    @Test
+    void matchByChildElementKeys() {
+        Document before = Document.of("<deps>"
+                + "<dep><g>junit</g><a>junit</a><v>4</v></dep>"
+                + "<dep><g>log4j</g><a>log4j</a><v>1</v></dep>"
+                + "</deps>");
+        Document after = Document.of("<deps>"
+                + "<dep><g>log4j</g><a>log4j</a><v>2</v></dep>"
+                + "<dep><g>junit</g><a>junit</a><v>5</v></dep>"
+                + "</deps>");
+
+        DiffConfig config = DiffConfig.builder().matchBy("dep", "g", "a").build();
+        DiffResult result = XmlDiff.diff(before, after, config);
+
+        // Should match by keys, not by position
+        List<XmlChange> textChanges = result.semanticChanges().stream()
+                .filter(c -> c.type() == ChangeType.TEXT_CHANGED)
+                .collect(Collectors.toList());
+        assertTrue(
+                textChanges.stream().anyMatch(c -> "4".equals(c.beforeValue()) && "5".equals(c.afterValue())),
+                "junit version should change from 4 to 5");
+        assertTrue(
+                textChanges.stream().anyMatch(c -> "1".equals(c.beforeValue()) && "2".equals(c.afterValue())),
+                "log4j version should change from 1 to 2");
+    }
+
+    @Test
+    void detectsElementMoved() {
+        Document before = Document.of(
+                "<deps>" + "<dep><g>junit</g><a>junit</a></dep>" + "<dep><g>log4j</g><a>log4j</a></dep>" + "</deps>");
+        Document after = Document.of(
+                "<deps>" + "<dep><g>log4j</g><a>log4j</a></dep>" + "<dep><g>junit</g><a>junit</a></dep>" + "</deps>");
+
+        DiffConfig config = DiffConfig.builder().matchBy("dep", "g", "a").build();
+        DiffResult result = XmlDiff.diff(before, after, config);
+
+        assertTrue(
+                result.changes().stream().anyMatch(c -> c.type() == ChangeType.ELEMENT_MOVED),
+                "Expected ELEMENT_MOVED for reordered elements");
+    }
+
+    @Test
+    void changesUnderFiltersByPath() {
+        Document before = Document.of("<project><version>1.0</version><name>old</name></project>");
+        Document after = Document.of("<project><version>2.0</version><name>new</name></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        List<XmlChange> versionChanges = result.changesUnder("/project/version");
+        assertEquals(1, versionChanges.size());
+        assertEquals(ChangeType.TEXT_CHANGED, versionChanges.get(0).type());
+    }
+
+    @Test
+    void semanticAndFormattingInSameDocument() {
+        // scope value changes (semantic) + type quote-only changes (formatting)
+        Document before = Document.of("<dep scope='compile' type='jar'>junit</dep>");
+        Document after = Document.of("<dep scope=\"test\" type=\"jar\">junit</dep>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertTrue(result.hasSemanticChanges(), "Expected semantic changes");
+        assertTrue(result.hasFormattingChanges(), "Expected formatting changes");
+        assertChange(result, ChangeType.ATTRIBUTE_CHANGED, "/dep/@scope", "compile", "test");
+        assertTrue(
+                result.formattingChanges().stream()
+                        .anyMatch(c -> c.type() == ChangeType.QUOTE_STYLE_CHANGED
+                                && c.path().equals("/dep/@type")),
+                "Expected QUOTE_STYLE_CHANGED for /dep/@type");
+    }
+
+    @Test
+    void differentRootElements() {
+        Document before = Document.of("<old>content</old>");
+        Document after = Document.of("<new>content</new>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ELEMENT_REMOVED, "/old");
+        assertChange(result, ChangeType.ELEMENT_ADDED, "/new");
+    }
+
+    @Test
+    void emptyDocuments() {
+        Document before = Document.of();
+        Document after = Document.of();
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertFalse(result.hasChanges());
+    }
+
+    @Test
+    void rootAddedToEmptyDocument() {
+        Document before = Document.of();
+        Document after = Document.of("<root/>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ELEMENT_ADDED, "/root");
+    }
+
+    @Test
+    void rootRemovedFromDocument() {
+        Document before = Document.of("<root/>");
+        Document after = Document.of();
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ELEMENT_REMOVED, "/root");
+    }
+
+    @Test
+    void multipleChangesInSameElement() {
+        Document before = Document.of("<e attr1=\"a\" attr2=\"b\">text</e>");
+        Document after = Document.of("<e attr1=\"x\" attr3=\"c\">changed</e>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.ATTRIBUTE_CHANGED, "/e/@attr1", "a", "x");
+        assertChange(result, ChangeType.ATTRIBUTE_REMOVED, "/e/@attr2", "b", null);
+        assertChange(result, ChangeType.ATTRIBUTE_ADDED, "/e/@attr3", null, "c");
+        assertChange(result, ChangeType.TEXT_CHANGED, "/e", "text", "changed");
+    }
+
+    @Test
+    void xmlChangeToString() {
+        XmlChange change = new XmlChange(ChangeType.TEXT_CHANGED, "/project/version", "1.0", "1.1", null, null);
+        assertEquals("TEXT_CHANGED: /project/version: \"1.0\" \u2192 \"1.1\"", change.toString());
+    }
+
+    @Test
+    void xmlChangeEquality() {
+        XmlChange a = new XmlChange(ChangeType.TEXT_CHANGED, "/project/version", "1.0", "1.1", null, null);
+        XmlChange b = new XmlChange(ChangeType.TEXT_CHANGED, "/project/version", "1.0", "1.1", null, null);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    void diffConfigDefaults() {
+        DiffConfig config = DiffConfig.defaults();
+        assertTrue(config.matchKeysFor("anything").isEmpty());
+        assertFalse(config.isOrderSensitive("any/path"));
+    }
+
+    @Test
+    void diffConfigBuilder() {
+        DiffConfig config = DiffConfig.builder()
+                .matchBy("dependency", "groupId", "artifactId")
+                .matchBy("*", "id")
+                .orderSensitive("modules/module")
+                .build();
+
+        assertEquals(2, config.matchKeysFor("dependency").size());
+        assertEquals(1, config.matchKeysFor("other").size()); // wildcard
+        assertTrue(config.isOrderSensitive("modules/module"));
+    }
+
+    @Test
+    void changeTypeClassification() {
+        assertTrue(ChangeType.ELEMENT_ADDED.isSemantic());
+        assertTrue(ChangeType.ELEMENT_REMOVED.isSemantic());
+        assertTrue(ChangeType.ELEMENT_MOVED.isSemantic());
+        assertTrue(ChangeType.TEXT_CHANGED.isSemantic());
+        assertTrue(ChangeType.ATTRIBUTE_ADDED.isSemantic());
+        assertTrue(ChangeType.ATTRIBUTE_REMOVED.isSemantic());
+        assertTrue(ChangeType.ATTRIBUTE_CHANGED.isSemantic());
+        assertTrue(ChangeType.COMMENT_ADDED.isSemantic());
+        assertTrue(ChangeType.COMMENT_REMOVED.isSemantic());
+        assertTrue(ChangeType.COMMENT_CHANGED.isSemantic());
+        assertTrue(ChangeType.NAMESPACE_CHANGED.isSemantic());
+
+        assertTrue(ChangeType.WHITESPACE_CHANGED.isFormattingOnly());
+        assertTrue(ChangeType.QUOTE_STYLE_CHANGED.isFormattingOnly());
+        assertTrue(ChangeType.ENTITY_FORM_CHANGED.isFormattingOnly());
+        assertTrue(ChangeType.EMPTY_ELEMENT_STYLE_CHANGED.isFormattingOnly());
+    }
+
+    @Test
+    void matchByAttributeKeys() {
+        Document before = Document.of("<items><item id=\"1\">A</item><item id=\"2\">B</item></items>");
+        Document after = Document.of("<items><item id=\"2\">B2</item><item id=\"1\">A</item></items>");
+
+        DiffConfig config = DiffConfig.builder().matchBy("item", "id").build();
+        DiffResult result = XmlDiff.diff(before, after, config);
+
+        assertTrue(
+                result.semanticChanges().stream()
+                        .anyMatch(c -> c.type() == ChangeType.TEXT_CHANGED
+                                && "B".equals(c.beforeValue())
+                                && "B2".equals(c.afterValue())),
+                "Expected text change B->B2 for item id=2");
+    }
+
+    @Test
+    void wildcardMatchKeys() {
+        Document before = Document.of("<root><thing id=\"x\">old</thing></root>");
+        Document after = Document.of("<root><thing id=\"x\">new</thing></root>");
+
+        DiffConfig config = DiffConfig.builder().matchBy("*", "id").build();
+        DiffResult result = XmlDiff.diff(before, after, config);
+
+        assertChange(result, ChangeType.TEXT_CHANGED, "/root/thing", "old", "new");
+    }
+
+    @Test
+    void diffResultToStringWithChanges() {
+        Document before = Document.of("<r><a>1</a><b>2</b></r>");
+        Document after = Document.of("<r><a>X</a><b>Y</b></r>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        String str = result.toString();
+        assertTrue(str.contains("TEXT_CHANGED"));
+        assertTrue(str.contains("/r/a"));
+        assertTrue(str.contains("/r/b"));
+    }
+
+    @Test
+    void noSemanticChangesWhenOnlyFormattingDiffers() {
+        Document before = Document.of("<dep scope='test'>junit</dep>");
+        Document after = Document.of("<dep scope=\"test\">junit</dep>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertTrue(result.hasChanges(), "Should detect formatting changes");
+        assertFalse(result.hasSemanticChanges(), "Should not have semantic changes");
+        assertTrue(result.hasFormattingChanges(), "Should have formatting changes");
+    }
+
+    @Test
+    void deeplyNestedPathGeneration() {
+        Document before = Document.of("<a><b><c><d>old</d></c></b></a>");
+        Document after = Document.of("<a><b><c><d>new</d></c></b></a>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.TEXT_CHANGED, "/a/b/c/d", "old", "new");
+    }
+
+    @Test
+    void detectsWhitespaceChange() {
+        Document before = Document.of("<project>\n  <version>1.0</version>\n</project>");
+        Document after = Document.of("<project>\n    <version>1.0</version>\n</project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertChange(result, ChangeType.WHITESPACE_CHANGED, "/project/version");
+        assertFalse(result.hasSemanticChanges(), "Whitespace-only change should not be semantic");
+        assertTrue(result.hasFormattingChanges(), "Should detect formatting changes");
+    }
+
+    @Test
+    void whitespaceOnlyDiffHasNoSemanticChanges() {
+        Document before =
+                Document.of("<project>\n  <groupId>org.example</groupId>\n  <version>1.0</version>\n</project>");
+        Document after =
+                Document.of("<project>\n    <groupId>org.example</groupId>\n    <version>1.0</version>\n</project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        assertTrue(result.hasChanges(), "Should detect whitespace changes");
+        assertTrue(result.semanticChanges().isEmpty(), "semanticChanges() should be empty for whitespace-only diff");
+        assertEquals(2, result.formattingChanges().size(), "Should have formatting changes for both elements");
+    }
+
+    @Test
+    void mixedSemanticAndWhitespaceChanges() {
+        Document before = Document.of("<project>\n  <version>1.0</version>\n  <name>old</name>\n</project>");
+        Document after = Document.of("<project>\n    <version>2.0</version>\n    <name>old</name>\n</project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        // Semantic: version text changed
+        List<XmlChange> semantic = result.semanticChanges();
+        assertEquals(1, semantic.size());
+        assertEquals(ChangeType.TEXT_CHANGED, semantic.get(0).type());
+        assertEquals("1.0", semantic.get(0).beforeValue());
+        assertEquals("2.0", semantic.get(0).afterValue());
+
+        // Formatting: whitespace changed on both elements
+        assertTrue(result.formattingChanges().size() >= 2, "Should have whitespace changes");
+    }
+
+    @Test
+    void changesForWithXPathExpression() {
+        String beforeXml = "<project>"
+                + "<dependencies>"
+                + "<dependency><groupId>junit</groupId><scope>test</scope><version>4</version></dependency>"
+                + "<dependency><groupId>log4j</groupId><scope>compile</scope><version>1</version></dependency>"
+                + "</dependencies>"
+                + "<version>1.0</version>"
+                + "</project>";
+        String afterXml = "<project>"
+                + "<dependencies>"
+                + "<dependency><groupId>junit</groupId><scope>test</scope><version>5</version></dependency>"
+                + "<dependency><groupId>log4j</groupId><scope>compile</scope><version>2</version></dependency>"
+                + "</dependencies>"
+                + "<version>2.0</version>"
+                + "</project>";
+
+        Document before = Document.of(beforeXml);
+        Document after = Document.of(afterXml);
+        DiffResult result = XmlDiff.diff(before, after);
+
+        // All changes (version + 2 dependency versions)
+        assertEquals(3, result.semanticChanges().size());
+
+        // Filter to test-scoped dependencies only
+        List<XmlChange> testChanges = result.changesFor("//dependency[scope='test']", after);
+        assertTrue(
+                testChanges.stream()
+                        .anyMatch(c -> c.type() == ChangeType.TEXT_CHANGED
+                                && "4".equals(c.beforeValue())
+                                && "5".equals(c.afterValue())),
+                "Should find junit version change");
+        assertFalse(
+                testChanges.stream().anyMatch(c -> "1".equals(c.beforeValue()) && "2".equals(c.afterValue())),
+                "Should not include log4j version change");
+
+        // Filter to project version only
+        List<XmlChange> versionChanges = result.changesFor("version", after);
+        assertEquals(1, versionChanges.size());
+        assertEquals("1.0", versionChanges.get(0).beforeValue());
+        assertEquals("2.0", versionChanges.get(0).afterValue());
+    }
+
+    @Test
+    void changesForWithNoMatches() {
+        Document before = Document.of("<project><version>1.0</version></project>");
+        Document after = Document.of("<project><version>2.0</version></project>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        List<XmlChange> noChanges = result.changesFor("//nonexistent", after);
+        assertTrue(noChanges.isEmpty());
+    }
+
+    // --- Assertion helpers ---
+
+    private static void assertChange(DiffResult result, ChangeType expectedType, String expectedPath) {
+        assertTrue(
+                result.changes().stream()
+                        .anyMatch(c -> c.type() == expectedType && c.path().equals(expectedPath)),
+                "Expected " + expectedType + " at " + expectedPath + " but got: " + result);
+    }
+
+    private static void assertChange(
+            DiffResult result, ChangeType expectedType, String expectedPath, String beforeValue, String afterValue) {
+        assertTrue(
+                result.changes().stream()
+                        .anyMatch(c -> c.type() == expectedType
+                                && c.path().equals(expectedPath)
+                                && Objects.equals(beforeValue, c.beforeValue())
+                                && Objects.equals(afterValue, c.afterValue())),
+                "Expected " + expectedType + " at " + expectedPath + " with before=" + beforeValue + " after="
+                        + afterValue + " but got: " + result);
+    }
+}

--- a/website/content/docs/features/index.md
+++ b/website/content/docs/features/index.md
@@ -58,6 +58,14 @@ Efficient processing of large XML documents with streaming capabilities.
 - **Streaming API** support
 - **Performance optimization**
 
+### [XML-Aware Structural Diff](xml-diff/)
+Compare two XML documents and detect both semantic and formatting-only changes.
+
+- **Semantic vs. formatting** change classification
+- **Configurable element matching** by identity keys
+- **Move detection** for reordered elements
+- **Path-based filtering** of changes
+
 ## Why These Features Matter
 
 ### ✅ **Perfect Round-Trip Editing**

--- a/website/content/docs/features/xml-diff.md
+++ b/website/content/docs/features/xml-diff.md
@@ -1,0 +1,217 @@
+---
+title: XML-Aware Structural Diff
+description: Compare two XML documents and detect both semantic and formatting-only changes using DomTrip's lossless formatting metadata
+layout: page
+---
+
+# XML-Aware Structural Diff
+
+DomTrip can compare two XML documents and report structural, content, and formatting differences. Because DomTrip preserves all formatting metadata (whitespace, quote styles, entity encoding, empty element style), the diff engine uniquely distinguishes **semantic changes** that affect meaning from **formatting-only changes** that are cosmetic.
+
+## Basic Usage
+
+```java
+Document before = Document.of(oldXml);
+Document after = Document.of(newXml);
+
+DiffResult diff = XmlDiff.diff(before, after);
+
+for (XmlChange change : diff.changes()) {
+    System.out.println(change);
+}
+// → TEXT_CHANGED: /project/version: "1.0" → "1.1"
+// → ATTRIBUTE_CHANGED: /project/dependencies/dependency[2]/@scope: "compile" → "test"
+// → ELEMENT_ADDED: /project/dependencies/dependency[3]
+```
+
+## Semantic vs. Formatting Changes
+
+The key differentiator is the ability to separate meaningful changes from noise:
+
+```java
+DiffResult diff = XmlDiff.diff(before, after);
+
+// Only changes that affect the XML's meaning
+List<XmlChange> meaningful = diff.semanticChanges();
+
+// Only cosmetic changes (whitespace, quotes, entity encoding)
+List<XmlChange> cosmetic = diff.formattingChanges();
+
+// Quick checks
+if (diff.hasSemanticChanges()) {
+    // Something meaningful changed
+}
+if (!diff.hasSemanticChanges() && diff.hasFormattingChanges()) {
+    // Documents are semantically identical, only formatting differs
+}
+```
+
+### Semantic Change Types
+
+| Change Type | Description |
+|---|---|
+| `ELEMENT_ADDED` | A new element was inserted |
+| `ELEMENT_REMOVED` | An element was deleted |
+| `ELEMENT_MOVED` | An element was reordered among siblings |
+| `TEXT_CHANGED` | Text content was modified |
+| `ATTRIBUTE_ADDED` | A new attribute was added |
+| `ATTRIBUTE_REMOVED` | An attribute was removed |
+| `ATTRIBUTE_CHANGED` | An attribute value was modified |
+| `COMMENT_ADDED` | A comment was inserted |
+| `COMMENT_REMOVED` | A comment was deleted |
+| `COMMENT_CHANGED` | Comment content was modified |
+| `NAMESPACE_CHANGED` | A namespace declaration was modified |
+
+### Formatting-Only Change Types
+
+| Change Type | Description |
+|---|---|
+| `WHITESPACE_CHANGED` | Indentation or spacing changed |
+| `QUOTE_STYLE_CHANGED` | Attribute quotes changed (single ↔ double) |
+| `ENTITY_FORM_CHANGED` | Entity encoding changed (e.g., `&lt;` vs `&#60;`) |
+| `EMPTY_ELEMENT_STYLE_CHANGED` | Self-closing style changed (`<br/>` ↔ `<br></br>`) |
+
+## Configurable Element Matching
+
+By default, same-name sibling elements are matched positionally. For domain-specific matching (e.g., Maven dependencies), configure identity keys:
+
+```java
+DiffConfig config = DiffConfig.builder()
+    .matchBy("dependency", "groupId", "artifactId")
+    .matchBy("plugin", "groupId", "artifactId")
+    .matchBy("*", "id")  // wildcard: match any element by "id"
+    .build();
+
+DiffResult diff = XmlDiff.diff(before, after, config);
+```
+
+Keys can refer to **child element names** (Maven-style, e.g., `groupId`) or **attribute names** (e.g., `id`). When keys are configured, the diff engine uses a two-phase matching algorithm:
+
+1. **Key-based matching** — elements with the same identity keys are paired regardless of position
+2. **Positional matching** — remaining unmatched elements are paired by position among same-name siblings
+
+This enables accurate **move detection** when elements are reordered:
+
+```java
+// Before: junit, then log4j
+// After: log4j, then junit (reordered)
+DiffConfig config = DiffConfig.builder()
+    .matchBy("dependency", "groupId", "artifactId")
+    .build();
+
+DiffResult diff = XmlDiff.diff(before, after, config);
+// → ELEMENT_MOVED: /dependencies/dependency (position 1 → 2)
+```
+
+## Filtering Changes
+
+### By Path Prefix
+
+Focus on changes in a specific part of the document:
+
+```java
+DiffResult diff = XmlDiff.diff(before, after);
+
+// Only changes under /project/dependencies
+List<XmlChange> depChanges = diff.changesUnder("/project/dependencies");
+```
+
+### By XPath Expression
+
+Use XPath expressions for richer filtering against the actual DOM tree:
+
+```java
+DiffResult diff = XmlDiff.diff(before, after);
+
+// Changes affecting test-scoped dependencies only
+List<XmlChange> testChanges = diff.changesFor("//dependency[scope='test']", after);
+
+// Changes affecting a specific plugin
+List<XmlChange> pluginChanges = diff.changesFor(
+    "//plugin[groupId='org.apache.maven.plugins']", after);
+```
+
+The `changesFor` method compiles the XPath expression, selects matching elements from the
+provided document, and returns all changes at or under those elements' paths.
+
+## Inspecting Changes
+
+Each `XmlChange` provides:
+
+```java
+for (XmlChange change : diff.changes()) {
+    ChangeType type = change.type();         // What kind of change
+    String path = change.path();             // XPath-like location
+    String before = change.beforeValue();    // Value before (null for additions)
+    String after = change.afterValue();      // Value after (null for removals)
+    boolean semantic = change.isSemantic();  // Does it affect meaning?
+
+    // Access the actual DOM nodes for deeper inspection
+    Node beforeNode = change.beforeNode();
+    Node afterNode = change.afterNode();
+}
+```
+
+## Use Cases
+
+### Configuration File Auditing
+
+Detect meaningful changes while ignoring reformatting:
+
+```java
+Document baseline = Document.of(Files.readString(baselinePath));
+Document current = Document.of(Files.readString(currentPath));
+
+DiffResult diff = XmlDiff.diff(baseline, current);
+if (diff.hasSemanticChanges()) {
+    System.out.println("Configuration has changed:");
+    diff.semanticChanges().forEach(System.out::println);
+} else if (diff.hasFormattingChanges()) {
+    System.out.println("Only formatting differences (no functional impact)");
+}
+```
+
+### Maven POM Comparison
+
+Compare POM files with identity-aware dependency matching:
+
+```java
+DiffConfig mavenConfig = DiffConfig.builder()
+    .matchBy("dependency", "groupId", "artifactId")
+    .matchBy("plugin", "groupId", "artifactId")
+    .matchBy("exclusion", "groupId", "artifactId")
+    .build();
+
+DiffResult diff = XmlDiff.diff(oldPom, newPom, mavenConfig);
+
+// Find version changes
+diff.semanticChanges().stream()
+    .filter(c -> c.type() == ChangeType.TEXT_CHANGED
+              && c.path().endsWith("/version"))
+    .forEach(c -> System.out.println(
+        c.path() + ": " + c.beforeValue() + " → " + c.afterValue()));
+```
+
+### Pre-Commit Validation
+
+Verify that only expected changes were made:
+
+```java
+DiffResult diff = XmlDiff.diff(original, modified);
+
+// Ensure no unexpected structural changes
+List<XmlChange> structural = diff.semanticChanges().stream()
+    .filter(c -> c.type() == ChangeType.ELEMENT_ADDED
+              || c.type() == ChangeType.ELEMENT_REMOVED)
+    .collect(Collectors.toList());
+
+if (!structural.isEmpty()) {
+    throw new ValidationException("Unexpected structural changes: " + structural);
+}
+```
+
+## Next Steps
+
+- [Formatting Preservation](../formatting-preservation/) — How DomTrip preserves formatting metadata
+- [Lossless Parsing](../lossless-parsing/) — Understanding the parsing process
+- [API Reference](../../api/) — Complete API documentation


### PR DESCRIPTION
## Summary

Closes #193

Add an XML-aware structural diff engine that compares two documents and reports all detected changes, uniquely distinguishing **semantic changes** from **formatting-only changes**. This leverages DomTrip's lossless formatting-preservation model — a capability no other Java XML library offers.

## New Public API (`@since 1.3.0`)

| Class | Description |
|---|---|
| `ChangeType` | Enum classifying 15 change types as semantic or formatting-only |
| `XmlChange` | Immutable change record with type, XPath-like path, values, and node references |
| `DiffConfig` | Configurable element matching via identity keys and wildcards |
| `DiffResult` | Filtered access to changes — semantic, formatting, by path, or by XPath expression |
| `XmlDiff` | Static diff engine with two-phase child matching (key-based, then positional) |

## Key Features

- **Semantic vs. formatting classification**: element/attribute/text/comment changes vs. whitespace, quote style, entity encoding, empty element style
- **Configurable identity matching**: match elements by child element or attribute keys (e.g., `groupId` + `artifactId` for Maven dependencies)
- **Move detection**: detects reordered elements when identity keys are configured
- **XPath-based filtering**: `changesFor("//dependency[scope='test']", doc)` using the mini-XPath from #196
- **Path-based filtering**: `changesUnder("/project/dependencies")` for simple prefix matching
- **Website documentation**: new feature page at `docs/features/xml-diff`

## Test plan

- [x] Identical documents produce empty diff
- [x] Text, attribute, element add/remove/change detection
- [x] Quote style, empty element style, whitespace formatting changes
- [x] Comment add/remove/change detection
- [x] Nested element changes with deep path generation
- [x] Positional indexing for same-name siblings
- [x] Key-based matching (child elements and attributes)
- [x] Element move detection
- [x] Semantic vs. formatting classification and filtering
- [x] `changesUnder()` path filtering
- [x] `changesFor()` XPath-based filtering
- [x] Different/empty root elements
- [x] Multiple changes in same element
- [x] Whitespace-only diffs produce no semantic changes
- [x] Mixed semantic + whitespace diffs filter correctly
- 38 tests total, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)