### PR TITLE
feat: add JPMS support with module-info.java descriptors

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,15 +56,42 @@
 
   <build>
     <plugins>
-      <!-- Enable annotation processing for test compilation (parent sets proc=none) -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>
           <execution>
+            <id>default-compile</id>
+            <configuration>
+              <release>8</release>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-module-info</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <includes>
+                <include>module-info.java</include>
+              </includes>
+            </configuration>
+          </execution>
+          <!-- Enable annotation processing for test compilation (parent sets proc=none) -->
+          <execution>
             <id>default-testCompile</id>
             <configuration>
               <proc>full</proc>
+              <compilerArgs>
+                <arg>--add-modules</arg>
+                <arg>java.xml</arg>
+                <arg>--add-reads</arg>
+                <arg>eu.maveniverse.domtrip=java.xml</arg>
+              </compilerArgs>
             </configuration>
           </execution>
         </executions>

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+/**
+ * DomTrip core module for lossless XML editing.
+ */
+module eu.maveniverse.domtrip {
+    exports eu.maveniverse.domtrip;
+}

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -38,6 +38,33 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <release>8</release>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-module-info</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <includes>
+                <include>module-info.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- Javadoc generation -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven/src/main/java/module-info.java
+++ b/maven/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+/**
+ * DomTrip Maven module for Maven-specific XML editing extensions.
+ */
+module eu.maveniverse.domtrip.maven {
+    exports eu.maveniverse.domtrip.maven;
+
+    requires transitive eu.maveniverse.domtrip;
+    requires java.logging;
+}


### PR DESCRIPTION
## Summary

Closes #199

- Add `module-info.java` to `domtrip-core` and `domtrip-maven` modules, making them proper JPMS named modules
- Use two-pass compilation (Java 8 main code + Java 9 module-info) to maintain Java 8 compatibility
- Configure test compilation with `--add-modules java.xml` for dom4j test dependency

### Module descriptors

**`eu.maveniverse.domtrip`** (core) — exports `eu.maveniverse.domtrip`, no external dependencies (only `java.base`)

**`eu.maveniverse.domtrip.maven`** — exports `eu.maveniverse.domtrip.maven`, requires `eu.maveniverse.domtrip` (transitive) and `java.logging`

## Test plan

- [x] `mvn install -pl core,maven` — all tests pass (303 maven + core tests)
- [x] `spotless:check` passes
- [x] `module-info.class` present in both JARs
- [x] Javadoc generation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to support Java Module System (JPMS) while maintaining Java 8 compatibility.
  * Configured multi-release compilation targeting Java 8 and Java 9+, enabling modular runtime support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->