### PR TITLE
feat: add SAX event output for pipeline composability

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/DomTripSAXSource.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DomTripSAXSource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import javax.xml.transform.sax.SAXSource;
+import org.xml.sax.InputSource;
+
+/**
+ * A {@link SAXSource} adapter that wraps a domtrip {@link Document} for use
+ * with JAXP APIs such as {@link javax.xml.transform.Transformer} and
+ * {@link javax.xml.validation.Validator}.
+ *
+ * <h3>Usage with Transformer:</h3>
+ * <pre>{@code
+ * Document doc = Document.of(xml);
+ * SAXSource source = DomTripSAXSource.of(doc);
+ * transformer.transform(source, result);
+ * }</pre>
+ *
+ * <h3>Usage with Validator:</h3>
+ * <pre>{@code
+ * Document doc = Document.of(xml);
+ * SAXSource source = DomTripSAXSource.of(doc);
+ * validator.validate(source);
+ * }</pre>
+ *
+ * @see SAXOutputter
+ * @see DomTripXMLReader
+ * @since 1.3.0
+ */
+public class DomTripSAXSource extends SAXSource {
+
+    /**
+     * Creates a new DomTripSAXSource wrapping the given document.
+     *
+     * @param document the domtrip document to wrap
+     * @throws IllegalArgumentException if document is null
+     */
+    public DomTripSAXSource(Document document) {
+        super(new DomTripXMLReader(document), new InputSource());
+    }
+
+    /**
+     * Creates a new DomTripSAXSource wrapping the given document.
+     *
+     * <p>This is a convenience factory method equivalent to calling the constructor.</p>
+     *
+     * @param document the domtrip document to wrap
+     * @return a new DomTripSAXSource
+     * @throws IllegalArgumentException if document is null
+     */
+    public static DomTripSAXSource of(Document document) {
+        return new DomTripSAXSource(document);
+    }
+}

--- a/core/src/main/java/eu/maveniverse/domtrip/DomTripXMLReader.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DomTripXMLReader.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import java.io.IOException;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.LexicalHandler;
+
+/**
+ * An {@link XMLReader} implementation that reads from a domtrip {@link Document}
+ * instead of parsing XML text.
+ *
+ * <p>This class is used internally by {@link DomTripSAXSource} to provide a
+ * {@link javax.xml.transform.sax.SAXSource} for JAXP interop. It can also be
+ * used directly when an {@code XMLReader} is needed.</p>
+ *
+ * <h3>Supported Features:</h3>
+ * <ul>
+ *   <li>{@code http://xml.org/sax/features/namespaces} &mdash; always {@code true}</li>
+ *   <li>{@code http://xml.org/sax/features/namespace-prefixes} &mdash; configurable,
+ *       controls whether namespace declarations appear as attributes</li>
+ * </ul>
+ *
+ * <h3>Supported Properties:</h3>
+ * <ul>
+ *   <li>{@code http://xml.org/sax/properties/lexical-handler} &mdash; set a
+ *       {@link LexicalHandler} for comment and CDATA events</li>
+ * </ul>
+ *
+ * @see DomTripSAXSource
+ * @see SAXOutputter
+ * @since 1.3.0
+ */
+public class DomTripXMLReader implements XMLReader {
+
+    /** SAX feature: namespace processing. */
+    private static final String FEATURE_NAMESPACES = "http://xml.org/sax/features/namespaces";
+
+    /** SAX feature: namespace-prefixes (report xmlns attributes). */
+    private static final String FEATURE_NAMESPACE_PREFIXES = "http://xml.org/sax/features/namespace-prefixes";
+
+    /** SAX property: lexical handler. */
+    private static final String PROPERTY_LEXICAL_HANDLER = "http://xml.org/sax/properties/lexical-handler";
+
+    private final Document document;
+
+    private ContentHandler contentHandler;
+    private DTDHandler dtdHandler;
+    private EntityResolver entityResolver;
+    private ErrorHandler errorHandler;
+    private LexicalHandler lexicalHandler;
+    private boolean namespacePrefixes;
+
+    /**
+     * Creates a new XMLReader that will read from the given document.
+     *
+     * @param document the domtrip document to read from
+     * @throws IllegalArgumentException if document is null
+     */
+    public DomTripXMLReader(Document document) {
+        if (document == null) {
+            throw new IllegalArgumentException("Document cannot be null");
+        }
+        this.document = document;
+    }
+
+    @Override
+    public boolean getFeature(String name) throws SAXNotRecognizedException {
+        if (FEATURE_NAMESPACES.equals(name)) {
+            return true;
+        }
+        if (FEATURE_NAMESPACE_PREFIXES.equals(name)) {
+            return namespacePrefixes;
+        }
+        throw new SAXNotRecognizedException("Feature: " + name);
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
+        if (FEATURE_NAMESPACES.equals(name)) {
+            if (!value) {
+                throw new SAXNotSupportedException("Namespace processing cannot be disabled");
+            }
+            return;
+        }
+        if (FEATURE_NAMESPACE_PREFIXES.equals(name)) {
+            this.namespacePrefixes = value;
+            return;
+        }
+        throw new SAXNotRecognizedException("Feature: " + name);
+    }
+
+    @Override
+    public Object getProperty(String name) throws SAXNotRecognizedException {
+        if (PROPERTY_LEXICAL_HANDLER.equals(name)) {
+            return lexicalHandler;
+        }
+        throw new SAXNotRecognizedException("Property: " + name);
+    }
+
+    @Override
+    public void setProperty(String name, Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
+        if (PROPERTY_LEXICAL_HANDLER.equals(name)) {
+            if (value != null && !(value instanceof LexicalHandler)) {
+                throw new SAXNotSupportedException("Property value must be a LexicalHandler");
+            }
+            this.lexicalHandler = (LexicalHandler) value;
+            return;
+        }
+        throw new SAXNotRecognizedException("Property: " + name);
+    }
+
+    @Override
+    public void setEntityResolver(EntityResolver resolver) {
+        this.entityResolver = resolver;
+    }
+
+    @Override
+    public EntityResolver getEntityResolver() {
+        return entityResolver;
+    }
+
+    @Override
+    public void setDTDHandler(DTDHandler handler) {
+        this.dtdHandler = handler;
+    }
+
+    @Override
+    public DTDHandler getDTDHandler() {
+        return dtdHandler;
+    }
+
+    @Override
+    public void setContentHandler(ContentHandler handler) {
+        this.contentHandler = handler;
+    }
+
+    @Override
+    public ContentHandler getContentHandler() {
+        return contentHandler;
+    }
+
+    @Override
+    public void setErrorHandler(ErrorHandler handler) {
+        this.errorHandler = handler;
+    }
+
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
+    /**
+     * Parses the domtrip document and emits SAX events.
+     *
+     * <p>The {@code input} parameter is ignored &mdash; the document provided
+     * at construction time is always used. This method exists to satisfy the
+     * {@link XMLReader} contract.</p>
+     *
+     * @param input ignored
+     * @throws SAXException if the content handler reports an error
+     */
+    @Override
+    public void parse(InputSource input) throws SAXException, IOException {
+        if (contentHandler == null) {
+            throw new SAXException("ContentHandler not set");
+        }
+
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.setReportNamespaceDeclarations(namespacePrefixes);
+        outputter.output(document, contentHandler, lexicalHandler);
+    }
+
+    /**
+     * Parses the domtrip document and emits SAX events.
+     *
+     * <p>The {@code systemId} parameter is ignored &mdash; the document provided
+     * at construction time is always used.</p>
+     *
+     * @param systemId ignored
+     * @throws SAXException if the content handler reports an error
+     */
+    @Override
+    public void parse(String systemId) throws SAXException, IOException {
+        parse(new InputSource(systemId));
+    }
+}

--- a/core/src/main/java/eu/maveniverse/domtrip/SAXOutputter.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/SAXOutputter.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.AttributesImpl;
+
+/**
+ * Emits SAX {@link ContentHandler} events from a domtrip {@link Document} tree.
+ *
+ * <p>This enables domtrip to participate in SAX-based XML processing pipelines,
+ * bridging the gap with dom4j's {@code SAXWriter} and JDOM2's {@code SAXOutputter}.
+ * The outputter walks the domtrip tree depth-first and emits the corresponding
+ * SAX events for each node.</p>
+ *
+ * <p>Note: formatting preservation is intentionally lost at the SAX boundary &mdash;
+ * SAX events don't carry formatting metadata. The value is interop, not round-tripping
+ * through SAX.</p>
+ *
+ * <h3>Basic Usage:</h3>
+ * <pre>{@code
+ * Document doc = Document.of(xml);
+ *
+ * SAXOutputter outputter = new SAXOutputter();
+ * outputter.output(doc, contentHandler);
+ * }</pre>
+ *
+ * <h3>With LexicalHandler:</h3>
+ * <pre>{@code
+ * SAXOutputter outputter = new SAXOutputter();
+ * outputter.output(doc, contentHandler, lexicalHandler);
+ * }</pre>
+ *
+ * @see DomTripSAXSource
+ * @see DomTripXMLReader
+ * @since 1.3.0
+ */
+public class SAXOutputter {
+
+    private boolean reportNamespaceDeclarations;
+
+    /**
+     * Creates a new SAXOutputter with default settings.
+     */
+    public SAXOutputter() {
+        this.reportNamespaceDeclarations = false;
+    }
+
+    /**
+     * Returns whether namespace declarations ({@code xmlns} attributes) are also
+     * reported as regular attributes in {@code startElement}.
+     *
+     * @return true if namespace declarations are reported as attributes
+     */
+    public boolean isReportNamespaceDeclarations() {
+        return reportNamespaceDeclarations;
+    }
+
+    /**
+     * Sets whether namespace declarations ({@code xmlns} attributes) should also
+     * be reported as regular attributes in {@code startElement}.
+     *
+     * <p>By default this is {@code false}, matching the SAX2 default where namespace
+     * declarations are reported only via {@code startPrefixMapping} /
+     * {@code endPrefixMapping}. Set to {@code true} to also include them in the
+     * {@code Attributes} parameter of {@code startElement}.</p>
+     *
+     * @param reportNamespaceDeclarations true to report namespace declarations as attributes
+     */
+    public void setReportNamespaceDeclarations(boolean reportNamespaceDeclarations) {
+        this.reportNamespaceDeclarations = reportNamespaceDeclarations;
+    }
+
+    /**
+     * Outputs SAX events for the given document to the specified content handler.
+     *
+     * @param document the domtrip document to output
+     * @param handler the SAX content handler to receive events
+     * @throws SAXException if the content handler reports an error
+     * @throws IllegalArgumentException if document or handler is null
+     */
+    public void output(Document document, ContentHandler handler) throws SAXException {
+        output(document, handler, null);
+    }
+
+    /**
+     * Outputs SAX events for the given document to the specified handlers.
+     *
+     * @param document the domtrip document to output
+     * @param handler the SAX content handler to receive events
+     * @param lexicalHandler optional lexical handler for comments and CDATA sections (may be null)
+     * @throws SAXException if a handler reports an error
+     * @throws IllegalArgumentException if document or handler is null
+     */
+    public void output(Document document, ContentHandler handler, LexicalHandler lexicalHandler) throws SAXException {
+        if (document == null) {
+            throw new IllegalArgumentException("Document cannot be null");
+        }
+        if (handler == null) {
+            throw new IllegalArgumentException("ContentHandler cannot be null");
+        }
+
+        handler.startDocument();
+
+        // Walk document children (includes root element and any PIs/comments)
+        for (Node child : new ArrayList<>(document.children)) {
+            outputNode(child, handler, lexicalHandler);
+        }
+        // Visit root element if set and not already in children
+        if (document.root() != null && !document.children.contains(document.root())) {
+            outputNode(document.root(), handler, lexicalHandler);
+        }
+
+        handler.endDocument();
+    }
+
+    private void outputNode(Node node, ContentHandler handler, LexicalHandler lexicalHandler) throws SAXException {
+        switch (node.type()) {
+            case ELEMENT:
+                outputElement((Element) node, handler, lexicalHandler);
+                break;
+            case TEXT:
+                outputText((Text) node, handler, lexicalHandler);
+                break;
+            case COMMENT:
+                outputComment((Comment) node, lexicalHandler);
+                break;
+            case PROCESSING_INSTRUCTION:
+                outputProcessingInstruction((ProcessingInstruction) node, handler);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void outputElement(Element element, ContentHandler handler, LexicalHandler lexicalHandler)
+            throws SAXException {
+        // Collect namespace declarations from this element's attributes
+        List<String[]> namespaceMappings = collectNamespaceDeclarations(element);
+
+        // Emit startPrefixMapping for each namespace declaration
+        for (String[] mapping : namespaceMappings) {
+            handler.startPrefixMapping(mapping[0], mapping[1]);
+        }
+
+        // Build SAX attributes (excluding namespace declarations unless configured)
+        AttributesImpl attrs = buildAttributes(element);
+
+        // Resolve element namespace
+        String[] parts = NamespaceResolver.splitQualifiedName(element.name());
+        String prefix = parts[0];
+        String localName = parts[1];
+        String namespaceURI = "";
+        if (prefix != null) {
+            String resolved = NamespaceResolver.resolveNamespaceURI(element, prefix);
+            if (resolved != null) {
+                namespaceURI = resolved;
+            }
+        } else {
+            // Check default namespace
+            String defaultNs = NamespaceResolver.resolveNamespaceURI(element, null);
+            if (defaultNs != null) {
+                namespaceURI = defaultNs;
+            }
+        }
+
+        handler.startElement(namespaceURI, localName, element.name(), attrs);
+
+        // Walk children
+        for (Node child : new ArrayList<>(element.children)) {
+            outputNode(child, handler, lexicalHandler);
+        }
+
+        handler.endElement(namespaceURI, localName, element.name());
+
+        // Emit endPrefixMapping in reverse order
+        for (int i = namespaceMappings.size() - 1; i >= 0; i--) {
+            handler.endPrefixMapping(namespaceMappings.get(i)[0]);
+        }
+    }
+
+    private void outputText(Text text, ContentHandler handler, LexicalHandler lexicalHandler) throws SAXException {
+        String content = text.content();
+        char[] chars = content.toCharArray();
+
+        if (text.cdata()) {
+            if (lexicalHandler != null) {
+                lexicalHandler.startCDATA();
+            }
+            handler.characters(chars, 0, chars.length);
+            if (lexicalHandler != null) {
+                lexicalHandler.endCDATA();
+            }
+        } else {
+            handler.characters(chars, 0, chars.length);
+        }
+    }
+
+    private void outputComment(Comment comment, LexicalHandler lexicalHandler) throws SAXException {
+        if (lexicalHandler != null) {
+            char[] chars = comment.content().toCharArray();
+            lexicalHandler.comment(chars, 0, chars.length);
+        }
+    }
+
+    private void outputProcessingInstruction(ProcessingInstruction pi, ContentHandler handler) throws SAXException {
+        handler.processingInstruction(pi.target(), pi.data());
+    }
+
+    /**
+     * Collects namespace declarations from an element's attributes.
+     *
+     * @return list of {prefix, uri} pairs; prefix is "" for default namespace
+     */
+    private List<String[]> collectNamespaceDeclarations(Element element) {
+        List<String[]> mappings = new ArrayList<>();
+        for (Map.Entry<String, String> entry : element.attributes().entrySet()) {
+            String attrName = entry.getKey();
+            String attrValue = entry.getValue();
+
+            if (Element.XMLNS.equals(attrName)) {
+                // Default namespace declaration
+                mappings.add(new String[] {"", attrValue});
+            } else if (attrName.startsWith(Element.XMLNS_PREFIX)) {
+                // Prefixed namespace declaration
+                String prefix = attrName.substring(Element.XMLNS_PREFIX.length());
+                mappings.add(new String[] {prefix, attrValue});
+            }
+        }
+        return mappings;
+    }
+
+    /**
+     * Builds SAX Attributes from element attributes, optionally excluding namespace declarations.
+     */
+    private AttributesImpl buildAttributes(Element element) {
+        AttributesImpl attrs = new AttributesImpl();
+
+        for (Map.Entry<String, String> entry : element.attributes().entrySet()) {
+            String attrName = entry.getKey();
+            String attrValue = entry.getValue();
+
+            // Skip namespace declarations unless reporting them
+            if (isNamespaceDeclaration(attrName)) {
+                if (reportNamespaceDeclarations) {
+                    String nsUri = NamespaceResolver.XMLNS_NAMESPACE_URI;
+                    String localName;
+                    if (Element.XMLNS.equals(attrName)) {
+                        localName = Element.XMLNS;
+                    } else {
+                        localName = attrName.substring(Element.XMLNS_PREFIX.length());
+                    }
+                    attrs.addAttribute(nsUri, localName, attrName, "CDATA", attrValue);
+                }
+                continue;
+            }
+
+            // Regular attribute
+            String[] parts = NamespaceResolver.splitQualifiedName(attrName);
+            String prefix = parts[0];
+            String localName = parts[1];
+            String namespaceURI = "";
+            if (prefix != null) {
+                String resolved = NamespaceResolver.resolveNamespaceURI(element, prefix);
+                if (resolved != null) {
+                    namespaceURI = resolved;
+                }
+            }
+
+            attrs.addAttribute(namespaceURI, localName, attrName, "CDATA", attrValue);
+        }
+
+        return attrs;
+    }
+
+    private static boolean isNamespaceDeclaration(String attrName) {
+        return Element.XMLNS.equals(attrName) || attrName.startsWith(Element.XMLNS_PREFIX);
+    }
+}

--- a/core/src/main/java/eu/maveniverse/domtrip/SAXOutputter.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/SAXOutputter.java
@@ -146,33 +146,20 @@ public class SAXOutputter {
     private void outputElement(Element element, ContentHandler handler, LexicalHandler lexicalHandler)
             throws SAXException {
         // Collect namespace declarations from this element's attributes
-        List<String[]> namespaceMappings = collectNamespaceDeclarations(element);
+        List<NamespaceMapping> namespaceMappings = collectNamespaceDeclarations(element);
 
         // Emit startPrefixMapping for each namespace declaration
-        for (String[] mapping : namespaceMappings) {
-            handler.startPrefixMapping(mapping[0], mapping[1]);
+        for (NamespaceMapping mapping : namespaceMappings) {
+            handler.startPrefixMapping(mapping.prefix, mapping.uri);
         }
 
         // Build SAX attributes (excluding namespace declarations unless configured)
         AttributesImpl attrs = buildAttributes(element);
 
         // Resolve element namespace
+        String namespaceURI = resolveElementNamespace(element);
         String[] parts = NamespaceResolver.splitQualifiedName(element.name());
-        String prefix = parts[0];
         String localName = parts[1];
-        String namespaceURI = "";
-        if (prefix != null) {
-            String resolved = NamespaceResolver.resolveNamespaceURI(element, prefix);
-            if (resolved != null) {
-                namespaceURI = resolved;
-            }
-        } else {
-            // Check default namespace
-            String defaultNs = NamespaceResolver.resolveNamespaceURI(element, null);
-            if (defaultNs != null) {
-                namespaceURI = defaultNs;
-            }
-        }
 
         handler.startElement(namespaceURI, localName, element.name(), attrs);
 
@@ -185,7 +172,7 @@ public class SAXOutputter {
 
         // Emit endPrefixMapping in reverse order
         for (int i = namespaceMappings.size() - 1; i >= 0; i--) {
-            handler.endPrefixMapping(namespaceMappings.get(i)[0]);
+            handler.endPrefixMapping(namespaceMappings.get(i).prefix);
         }
     }
 
@@ -218,23 +205,36 @@ public class SAXOutputter {
     }
 
     /**
+     * Resolves the namespace URI for an element based on its prefix or the default namespace.
+     */
+    private static String resolveElementNamespace(Element element) {
+        String[] parts = NamespaceResolver.splitQualifiedName(element.name());
+        String prefix = parts[0];
+        String resolved;
+        if (prefix != null) {
+            resolved = NamespaceResolver.resolveNamespaceURI(element, prefix);
+        } else {
+            resolved = NamespaceResolver.resolveNamespaceURI(element, null);
+        }
+        return resolved != null ? resolved : "";
+    }
+
+    /**
      * Collects namespace declarations from an element's attributes.
      *
-     * @return list of {prefix, uri} pairs; prefix is "" for default namespace
+     * @return list of namespace mappings; prefix is "" for default namespace
      */
-    private List<String[]> collectNamespaceDeclarations(Element element) {
-        List<String[]> mappings = new ArrayList<>();
+    private List<NamespaceMapping> collectNamespaceDeclarations(Element element) {
+        List<NamespaceMapping> mappings = new ArrayList<>();
         for (Map.Entry<String, String> entry : element.attributes().entrySet()) {
             String attrName = entry.getKey();
             String attrValue = entry.getValue();
 
             if (Element.XMLNS.equals(attrName)) {
-                // Default namespace declaration
-                mappings.add(new String[] {"", attrValue});
+                mappings.add(new NamespaceMapping("", attrValue));
             } else if (attrName.startsWith(Element.XMLNS_PREFIX)) {
-                // Prefixed namespace declaration
                 String prefix = attrName.substring(Element.XMLNS_PREFIX.length());
-                mappings.add(new String[] {prefix, attrValue});
+                mappings.add(new NamespaceMapping(prefix, attrValue));
             }
         }
         return mappings;
@@ -250,40 +250,53 @@ public class SAXOutputter {
             String attrName = entry.getKey();
             String attrValue = entry.getValue();
 
-            // Skip namespace declarations unless reporting them
             if (isNamespaceDeclaration(attrName)) {
                 if (reportNamespaceDeclarations) {
-                    String nsUri = NamespaceResolver.XMLNS_NAMESPACE_URI;
-                    String localName;
-                    if (Element.XMLNS.equals(attrName)) {
-                        localName = Element.XMLNS;
-                    } else {
-                        localName = attrName.substring(Element.XMLNS_PREFIX.length());
-                    }
-                    attrs.addAttribute(nsUri, localName, attrName, "CDATA", attrValue);
+                    addNamespaceAttribute(attrs, attrName, attrValue);
                 }
                 continue;
             }
 
-            // Regular attribute
-            String[] parts = NamespaceResolver.splitQualifiedName(attrName);
-            String prefix = parts[0];
-            String localName = parts[1];
-            String namespaceURI = "";
-            if (prefix != null) {
-                String resolved = NamespaceResolver.resolveNamespaceURI(element, prefix);
-                if (resolved != null) {
-                    namespaceURI = resolved;
-                }
-            }
-
-            attrs.addAttribute(namespaceURI, localName, attrName, "CDATA", attrValue);
+            addRegularAttribute(attrs, element, attrName, attrValue);
         }
 
         return attrs;
     }
 
+    private static void addNamespaceAttribute(AttributesImpl attrs, String attrName, String attrValue) {
+        String localName =
+                Element.XMLNS.equals(attrName) ? Element.XMLNS : attrName.substring(Element.XMLNS_PREFIX.length());
+        attrs.addAttribute(NamespaceResolver.XMLNS_NAMESPACE_URI, localName, attrName, "CDATA", attrValue);
+    }
+
+    private static void addRegularAttribute(AttributesImpl attrs, Element element, String attrName, String attrValue) {
+        String[] parts = NamespaceResolver.splitQualifiedName(attrName);
+        String prefix = parts[0];
+        String localName = parts[1];
+        String namespaceURI = "";
+        if (prefix != null) {
+            String resolved = NamespaceResolver.resolveNamespaceURI(element, prefix);
+            if (resolved != null) {
+                namespaceURI = resolved;
+            }
+        }
+        attrs.addAttribute(namespaceURI, localName, attrName, "CDATA", attrValue);
+    }
+
     private static boolean isNamespaceDeclaration(String attrName) {
         return Element.XMLNS.equals(attrName) || attrName.startsWith(Element.XMLNS_PREFIX);
+    }
+
+    /**
+     * A namespace prefix-to-URI mapping collected from an element's namespace declarations.
+     */
+    private static final class NamespaceMapping {
+        final String prefix;
+        final String uri;
+
+        NamespaceMapping(String prefix, String uri) {
+            this.prefix = prefix;
+            this.uri = uri;
+        }
     }
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -10,5 +10,7 @@
  * DomTrip core module for lossless XML editing.
  */
 module eu.maveniverse.domtrip {
+    requires java.xml;
+
     exports eu.maveniverse.domtrip;
 }

--- a/core/src/test/java/eu/maveniverse/domtrip/SAXOutputterTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/SAXOutputterTest.java
@@ -306,7 +306,8 @@ class SAXOutputterTest {
     @Test
     void nullDocumentThrows() {
         SAXOutputter outputter = new SAXOutputter();
-        assertThrows(IllegalArgumentException.class, () -> outputter.output(null, new DefaultHandler()));
+        DefaultHandler handler = new DefaultHandler();
+        assertThrows(IllegalArgumentException.class, () -> outputter.output(null, handler));
     }
 
     @Test

--- a/core/src/test/java/eu/maveniverse/domtrip/SAXOutputterTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/SAXOutputterTest.java
@@ -1,0 +1,552 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.domtrip;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.LexicalHandler;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Tests for {@link SAXOutputter}, {@link DomTripXMLReader}, and {@link DomTripSAXSource}.
+ */
+class SAXOutputterTest {
+
+    @Test
+    void simpleDocumentEmitsCorrectEventSequence() throws Exception {
+        Document doc = Document.of("<root><child>text</child></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        List<String> events = recorder.events;
+        assertTrue(events.contains("startDocument"), "Should emit startDocument");
+        assertTrue(events.contains("startElement: :root:root"), "Should emit startElement for root");
+        assertTrue(events.contains("startElement: :child:child"), "Should emit startElement for child");
+        assertTrue(events.contains("characters: text"), "Should emit characters");
+        assertTrue(events.contains("endElement: :child:child"), "Should emit endElement for child");
+        assertTrue(events.contains("endElement: :root:root"), "Should emit endElement for root");
+        assertTrue(events.contains("endDocument"), "Should emit endDocument");
+
+        // Verify order: startDocument is first, endDocument is last
+        assertEquals("startDocument", events.get(0));
+        assertEquals("endDocument", events.get(events.size() - 1));
+    }
+
+    @Test
+    void namespaceDeclarationsEmitPrefixMappings() throws Exception {
+        Document doc = Document.of(
+                "<root xmlns=\"http://example.com\" xmlns:p=\"http://prefix.com\">" + "<p:child>text</p:child></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        assertTrue(
+                recorder.events.contains("startPrefixMapping: =http://example.com"),
+                "Should emit default namespace mapping");
+        assertTrue(
+                recorder.events.contains("startPrefixMapping: p=http://prefix.com"),
+                "Should emit prefixed namespace mapping");
+        assertTrue(recorder.events.contains("endPrefixMapping: "), "Should emit endPrefixMapping for default");
+        assertTrue(recorder.events.contains("endPrefixMapping: p"), "Should emit endPrefixMapping for p");
+
+        // Verify namespace URI in startElement
+        assertTrue(recorder.events.contains("startElement: http://example.com:root:root"));
+        assertTrue(recorder.events.contains("startElement: http://prefix.com:child:p:child"));
+    }
+
+    @Test
+    void attributesReportedCorrectly() throws Exception {
+        Document doc = Document.of("<root attr1=\"value1\" attr2=\"value2\"/>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        // Find the startElement event to check attributes
+        assertTrue(recorder.attributeRecords.stream()
+                .anyMatch(a -> a.localName.equals("attr1") && a.value.equals("value1")));
+        assertTrue(recorder.attributeRecords.stream()
+                .anyMatch(a -> a.localName.equals("attr2") && a.value.equals("value2")));
+    }
+
+    @Test
+    void namespacedAttributesResolvedCorrectly() throws Exception {
+        Document doc =
+                Document.of("<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"myType\"/>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        assertTrue(recorder.attributeRecords.stream()
+                .anyMatch(a -> a.uri.equals("http://www.w3.org/2001/XMLSchema-instance")
+                        && a.localName.equals("type")
+                        && a.value.equals("myType")));
+    }
+
+    @Test
+    void cdataSectionsEmitLexicalEvents() throws Exception {
+        Document doc = Document.of("<root><![CDATA[some <data>]]></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        LexicalRecorder lexRecorder = new LexicalRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder, lexRecorder);
+
+        assertTrue(lexRecorder.events.contains("startCDATA"), "Should emit startCDATA");
+        assertTrue(lexRecorder.events.contains("endCDATA"), "Should emit endCDATA");
+        assertTrue(recorder.events.contains("characters: some <data>"), "Should emit CDATA content as characters");
+    }
+
+    @Test
+    void cdataWithoutLexicalHandlerStillEmitsCharacters() throws Exception {
+        Document doc = Document.of("<root><![CDATA[data]]></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        assertTrue(recorder.events.contains("characters: data"));
+    }
+
+    @Test
+    void commentsEmitLexicalEvents() throws Exception {
+        Document doc = Document.of("<root><!-- a comment --></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        LexicalRecorder lexRecorder = new LexicalRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder, lexRecorder);
+
+        assertTrue(lexRecorder.events.contains("comment:  a comment "), "Should emit comment");
+    }
+
+    @Test
+    void commentsWithoutLexicalHandlerAreSkipped() throws Exception {
+        Document doc = Document.of("<root><!-- a comment --><child/></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        // Should not throw, and should still process other nodes
+        assertTrue(recorder.events.contains("startElement: :child:child"));
+    }
+
+    @Test
+    void processingInstructionsEmitEvents() throws Exception {
+        Document doc = Document.of("<root><?target data?></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        assertTrue(recorder.events.contains("processingInstruction: target data"), "Should emit processingInstruction");
+    }
+
+    @Test
+    void mixedContent() throws Exception {
+        Document doc = Document.of("<root>text1<child/>text2</root>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.output(doc, recorder);
+
+        // Verify interleaved text and elements
+        int text1Idx = recorder.events.indexOf("characters: text1");
+        int childStart = recorder.events.indexOf("startElement: :child:child");
+        int text2Idx = recorder.events.indexOf("characters: text2");
+
+        assertTrue(text1Idx < childStart, "text1 before child");
+        assertTrue(childStart < text2Idx, "child before text2");
+    }
+
+    @Test
+    void emptyElementsBothStyles() throws Exception {
+        // Self-closing
+        Document doc1 = Document.of("<root><empty/></root>");
+        EventRecorder rec1 = new EventRecorder();
+        new SAXOutputter().output(doc1, rec1);
+
+        assertTrue(rec1.events.contains("startElement: :empty:empty"));
+        assertTrue(rec1.events.contains("endElement: :empty:empty"));
+
+        // Expanded empty
+        Document doc2 = Document.of("<root><empty></empty></root>");
+        EventRecorder rec2 = new EventRecorder();
+        new SAXOutputter().output(doc2, rec2);
+
+        assertTrue(rec2.events.contains("startElement: :empty:empty"));
+        assertTrue(rec2.events.contains("endElement: :empty:empty"));
+    }
+
+    @Test
+    void deeplyNestedStructure() throws Exception {
+        Document doc = Document.of("<a><b><c><d><e>deep</e></d></c></b></a>");
+
+        EventRecorder recorder = new EventRecorder();
+        new SAXOutputter().output(doc, recorder);
+
+        assertTrue(recorder.events.contains("startElement: :e:e"));
+        assertTrue(recorder.events.contains("characters: deep"));
+
+        // Verify proper nesting: all opens come before their closes
+        int aStart = recorder.events.indexOf("startElement: :a:a");
+        int eEnd = recorder.events.indexOf("endElement: :e:e");
+        int aEnd = recorder.events.indexOf("endElement: :a:a");
+        assertTrue(aStart < eEnd && eEnd < aEnd);
+    }
+
+    @Test
+    void reportNamespaceDeclarationsAsAttributes() throws Exception {
+        Document doc = Document.of("<root xmlns=\"http://example.com\" xmlns:p=\"http://prefix.com\"/>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.setReportNamespaceDeclarations(true);
+        outputter.output(doc, recorder);
+
+        assertTrue(recorder.attributeRecords.stream()
+                .anyMatch(a -> a.qName.equals("xmlns") && a.value.equals("http://example.com")));
+        assertTrue(recorder.attributeRecords.stream()
+                .anyMatch(a -> a.qName.equals("xmlns:p") && a.value.equals("http://prefix.com")));
+    }
+
+    @Test
+    void namespaceDeclarationsExcludedByDefault() throws Exception {
+        Document doc = Document.of("<root xmlns=\"http://example.com\" attr=\"val\"/>");
+
+        EventRecorder recorder = new EventRecorder();
+        SAXOutputter outputter = new SAXOutputter();
+        outputter.setReportNamespaceDeclarations(false);
+        outputter.output(doc, recorder);
+
+        assertEquals(1, recorder.attributeRecords.size(), "Only non-namespace attributes");
+        assertEquals("attr", recorder.attributeRecords.get(0).localName);
+    }
+
+    @Test
+    void roundTripViaDOMResult() throws Exception {
+        String xml = "<root xmlns=\"http://example.com\"><child attr=\"value\">text</child></root>";
+        Document doc = Document.of(xml);
+
+        SAXSource source = DomTripSAXSource.of(doc);
+        DOMResult result = new DOMResult();
+
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        transformer.transform(source, result);
+
+        org.w3c.dom.Document domDoc = (org.w3c.dom.Document) result.getNode();
+        assertNotNull(domDoc.getDocumentElement());
+        assertEquals("root", domDoc.getDocumentElement().getLocalName());
+        assertEquals("http://example.com", domDoc.getDocumentElement().getNamespaceURI());
+
+        org.w3c.dom.NodeList children = domDoc.getDocumentElement().getChildNodes();
+        boolean foundChild = false;
+        for (int i = 0; i < children.getLength(); i++) {
+            org.w3c.dom.Node child = children.item(i);
+            if (child instanceof org.w3c.dom.Element) {
+                org.w3c.dom.Element childElem = (org.w3c.dom.Element) child;
+                assertEquals("child", childElem.getLocalName());
+                assertEquals("value", childElem.getAttribute("attr"));
+                assertEquals("text", childElem.getTextContent());
+                foundChild = true;
+            }
+        }
+        assertTrue(foundChild, "Should find child element in DOM result");
+    }
+
+    @Test
+    void xsltTransformation() throws Exception {
+        String xml = "<items><item>one</item><item>two</item></items>";
+        String xslt = "<?xml version=\"1.0\"?>"
+                + "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">"
+                + "<xsl:output method=\"text\"/>"
+                + "<xsl:template match=\"/\">"
+                + "<xsl:for-each select=\"items/item\">"
+                + "<xsl:value-of select=\".\"/><xsl:text> </xsl:text>"
+                + "</xsl:for-each>"
+                + "</xsl:template>"
+                + "</xsl:stylesheet>";
+
+        Document doc = Document.of(xml);
+        SAXSource source = DomTripSAXSource.of(doc);
+
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer(new StreamSource(new StringReader(xslt)));
+
+        StringWriter writer = new StringWriter();
+        transformer.transform(source, new StreamResult(writer));
+
+        assertEquals("one two ", writer.toString());
+    }
+
+    @Test
+    void nullDocumentThrows() {
+        SAXOutputter outputter = new SAXOutputter();
+        assertThrows(IllegalArgumentException.class, () -> outputter.output(null, new DefaultHandler()));
+    }
+
+    @Test
+    void nullHandlerThrows() {
+        Document doc = Document.of("<root/>");
+        SAXOutputter outputter = new SAXOutputter();
+        assertThrows(IllegalArgumentException.class, () -> outputter.output(doc, null));
+    }
+
+    @Test
+    void domTripXMLReaderNullDocumentThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new DomTripXMLReader(null));
+    }
+
+    @Test
+    void domTripXMLReaderFeaturesAndProperties() throws Exception {
+        Document doc = Document.of("<root/>");
+        DomTripXMLReader reader = new DomTripXMLReader(doc);
+
+        // Namespaces always true
+        assertTrue(reader.getFeature("http://xml.org/sax/features/namespaces"));
+        assertThrows(
+                org.xml.sax.SAXNotSupportedException.class,
+                () -> reader.setFeature("http://xml.org/sax/features/namespaces", false));
+
+        // Namespace prefixes configurable
+        assertFalse(reader.getFeature("http://xml.org/sax/features/namespace-prefixes"));
+        reader.setFeature("http://xml.org/sax/features/namespace-prefixes", true);
+        assertTrue(reader.getFeature("http://xml.org/sax/features/namespace-prefixes"));
+
+        // Unknown feature throws
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> reader.getFeature("http://unknown"));
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> reader.setFeature("http://unknown", true));
+
+        // Lexical handler property
+        assertNull(reader.getProperty("http://xml.org/sax/properties/lexical-handler"));
+        LexicalRecorder lex = new LexicalRecorder();
+        reader.setProperty("http://xml.org/sax/properties/lexical-handler", lex);
+        assertSame(lex, reader.getProperty("http://xml.org/sax/properties/lexical-handler"));
+
+        // Unknown property throws
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> reader.getProperty("http://unknown"));
+        assertThrows(org.xml.sax.SAXNotRecognizedException.class, () -> reader.setProperty("http://unknown", "value"));
+    }
+
+    @Test
+    void domTripXMLReaderParseWithoutContentHandlerThrows() {
+        Document doc = Document.of("<root/>");
+        DomTripXMLReader reader = new DomTripXMLReader(doc);
+        assertThrows(SAXException.class, () -> reader.parse("systemId"));
+    }
+
+    @Test
+    void domTripXMLReaderHandlerAccessors() {
+        Document doc = Document.of("<root/>");
+        DomTripXMLReader reader = new DomTripXMLReader(doc);
+
+        DefaultHandler handler = new DefaultHandler();
+        reader.setContentHandler(handler);
+        assertSame(handler, reader.getContentHandler());
+
+        reader.setDTDHandler(handler);
+        assertSame(handler, reader.getDTDHandler());
+
+        reader.setEntityResolver(handler);
+        assertSame(handler, reader.getEntityResolver());
+
+        reader.setErrorHandler(handler);
+        assertSame(handler, reader.getErrorHandler());
+    }
+
+    @Test
+    void domTripSAXSourceFactoryMethod() {
+        Document doc = Document.of("<root/>");
+        DomTripSAXSource source = DomTripSAXSource.of(doc);
+        assertNotNull(source);
+        assertNotNull(source.getXMLReader());
+        assertNotNull(source.getInputSource());
+    }
+
+    @Test
+    void domTripSAXSourceNullDocumentThrows() {
+        assertThrows(IllegalArgumentException.class, () -> DomTripSAXSource.of(null));
+    }
+
+    @Test
+    void documentLevelProcessingInstruction() throws Exception {
+        Document doc = Document.of("<?xml version=\"1.0\"?><?style type=\"text/css\"?><root/>");
+
+        EventRecorder recorder = new EventRecorder();
+        new SAXOutputter().output(doc, recorder);
+
+        assertTrue(recorder.events.contains("processingInstruction: style type=\"text/css\""));
+    }
+
+    @Test
+    void documentLevelComment() throws Exception {
+        Document doc = Document.of("<!-- doc comment --><root/>");
+
+        LexicalRecorder lexRecorder = new LexicalRecorder();
+        new SAXOutputter().output(doc, new DefaultHandler(), lexRecorder);
+
+        assertTrue(lexRecorder.events.contains("comment:  doc comment "));
+    }
+
+    @Test
+    void multipleNamespacesOnSameElement() throws Exception {
+        Document doc =
+                Document.of("<root xmlns:a=\"http://a.com\" xmlns:b=\"http://b.com\">" + "<a:child/><b:other/></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        new SAXOutputter().output(doc, recorder);
+
+        assertTrue(recorder.events.contains("startPrefixMapping: a=http://a.com"));
+        assertTrue(recorder.events.contains("startPrefixMapping: b=http://b.com"));
+        assertTrue(recorder.events.contains("startElement: http://a.com:child:a:child"));
+        assertTrue(recorder.events.contains("startElement: http://b.com:other:b:other"));
+    }
+
+    @Test
+    void defaultNamespaceInherited() throws Exception {
+        Document doc = Document.of("<root xmlns=\"http://example.com\"><child/></root>");
+
+        EventRecorder recorder = new EventRecorder();
+        new SAXOutputter().output(doc, recorder);
+
+        // child should inherit the default namespace
+        assertTrue(recorder.events.contains("startElement: http://example.com:child:child"));
+    }
+
+    @Test
+    void isReportNamespaceDeclarationsDefault() {
+        SAXOutputter outputter = new SAXOutputter();
+        assertFalse(outputter.isReportNamespaceDeclarations());
+    }
+
+    // -- Helper classes --
+
+    /** Records SAX ContentHandler events. */
+    private static class EventRecorder extends DefaultHandler {
+        final List<String> events = new ArrayList<>();
+        final List<AttributeRecord> attributeRecords = new ArrayList<>();
+
+        @Override
+        public void startDocument() {
+            events.add("startDocument");
+        }
+
+        @Override
+        public void endDocument() {
+            events.add("endDocument");
+        }
+
+        @Override
+        public void startPrefixMapping(String prefix, String uri) {
+            events.add("startPrefixMapping: " + prefix + "=" + uri);
+        }
+
+        @Override
+        public void endPrefixMapping(String prefix) {
+            events.add("endPrefixMapping: " + prefix);
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes atts) {
+            events.add("startElement: " + uri + ":" + localName + ":" + qName);
+            for (int i = 0; i < atts.getLength(); i++) {
+                attributeRecords.add(
+                        new AttributeRecord(atts.getURI(i), atts.getLocalName(i), atts.getQName(i), atts.getValue(i)));
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) {
+            events.add("endElement: " + uri + ":" + localName + ":" + qName);
+        }
+
+        @Override
+        public void characters(char[] ch, int start, int length) {
+            events.add("characters: " + new String(ch, start, length));
+        }
+
+        @Override
+        public void processingInstruction(String target, String data) {
+            events.add("processingInstruction: " + target + " " + data);
+        }
+    }
+
+    /** Records SAX LexicalHandler events. */
+    private static class LexicalRecorder implements LexicalHandler {
+        final List<String> events = new ArrayList<>();
+
+        @Override
+        public void startDTD(String name, String publicId, String systemId) {
+            events.add("startDTD: " + name);
+        }
+
+        @Override
+        public void endDTD() {
+            events.add("endDTD");
+        }
+
+        @Override
+        public void startEntity(String name) {
+            events.add("startEntity: " + name);
+        }
+
+        @Override
+        public void endEntity(String name) {
+            events.add("endEntity: " + name);
+        }
+
+        @Override
+        public void startCDATA() {
+            events.add("startCDATA");
+        }
+
+        @Override
+        public void endCDATA() {
+            events.add("endCDATA");
+        }
+
+        @Override
+        public void comment(char[] ch, int start, int length) {
+            events.add("comment: " + new String(ch, start, length));
+        }
+    }
+
+    /** Records attribute details from startElement calls. */
+    private static class AttributeRecord {
+        final String uri;
+        final String localName;
+        final String qName;
+        final String value;
+
+        AttributeRecord(String uri, String localName, String qName, String value) {
+            this.uri = uri;
+            this.localName = localName;
+            this.qName = qName;
+            this.value = value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #194

Add a `SAXOutputter` that emits SAX `ContentHandler` events from a domtrip `Document` tree, enabling domtrip to participate in SAX-based XML processing pipelines.

**New classes:**
- `SAXOutputter` — walks the domtrip tree depth-first and emits corresponding SAX events
- `DomTripXMLReader` — `XMLReader` implementation for use with `SAXSource`
- `DomTripSAXSource` — `SAXSource` adapter for JAXP interop (Transformer, Validator)

**SAX events emitted:**
| domtrip Node | SAX Event(s) |
|---|---|
| `Document` start/end | `startDocument()` / `endDocument()` |
| `Element` open/close | `startPrefixMapping()`, `startElement()` / `endElement()`, `endPrefixMapping()` |
| `Text` (regular) | `characters()` |
| `Text` (CDATA) | `startCDATA()`, `characters()`, `endCDATA()` (via `LexicalHandler`) |
| `Comment` | `comment()` (via `LexicalHandler`) |
| `ProcessingInstruction` | `processingInstruction()` |

**Namespace handling:**
- Namespace declarations on each element emit `startPrefixMapping` / `endPrefixMapping`
- Element and attribute namespace URIs are resolved via `NamespaceResolver`
- Optional `reportNamespaceDeclarations` flag to also include xmlns attrs in `Attributes`

**JPMS:** Added `requires java.xml;` to `module-info.java`.

## Test plan

- [x] Simple document → correct event sequence (startDocument, startElement, characters, endElement, endDocument)
- [x] Namespace declarations → startPrefixMapping/endPrefixMapping pairs
- [x] Attributes → correct Attributes object in startElement
- [x] Namespaced attributes → correct namespace URI resolution
- [x] CDATA sections → LexicalHandler startCDATA/endCDATA events
- [x] Comments → LexicalHandler comment() events
- [x] Processing instructions → processingInstruction() events
- [x] Mixed content (text + elements interleaved)
- [x] Empty elements (both self-closing and expanded)
- [x] Deeply nested structure
- [x] Round-trip: domtrip → SAX → DOMResult → verify structure preserved
- [x] XSLT: domtrip → SAX → Transformer → verify output
- [x] Multiple namespaces on same element
- [x] Default namespace inheritance
- [x] XMLReader feature/property accessors
- [x] Null argument validation
- [x] Full test suite: 1427 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SAX (Simple API for XML) event stream support, enabling conversion of documents to SAX events for integration with standard Java XML transformation tools.
  * Supports namespace handling, attributes, comments, CDATA sections, and processing instructions in SAX output.

* **Tests**
  * Added comprehensive test suite covering SAX event processing, namespace handling, attribute reporting, and XML transformation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->