### PR TITLE
docs: update README with new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,25 @@
 
 **Lossless XML Editing for Java**
 
-[![Maven Central](https://img.shields.io/maven-central/v/eu.maveniverse.maven.domtrip/domtrip.svg)](https://central.sonatype.com/artifact/eu.maveniverse.maven.domtrip/domtrip)
+[![Maven Central](https://img.shields.io/maven-central/v/eu.maveniverse.maven.domtrip/domtrip-core.svg)](https://central.sonatype.com/artifact/eu.maveniverse.maven.domtrip/domtrip-core)
 [![GitHub](https://img.shields.io/github/license/maveniverse/domtrip.svg)](https://github.com/maveniverse/domtrip/blob/master/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-website-blue.svg)](https://maveniverse.github.io/domtrip/)
 
 DomTrip is a Java library for lossless XML editing that preserves every detail of your XML documents during round-trip operations. Perfect for configuration file editing, document transformation, and any scenario where maintaining original formatting is crucial.
 
-## 🎯 Why DomTrip?
+## Why DomTrip?
 
-- **🔄 Perfect Round-Trip**: Preserves comments, whitespace, entity encoding, attribute quote styles, and formatting
-- **📝 Easy Editing**: Make changes while keeping original formatting intact
-- **🚀 Modern API**: Built for Java 8+ with fluent builders, Stream-based navigation, and type-safe configuration
-- **🌐 Namespace Aware**: Comprehensive XML namespace support with resolution and context management
-- **⚡ Performance**: Minimal-change serialization - only modified sections are reformatted
+- **Perfect Round-Trip**: Preserves comments, whitespace, entity encoding, attribute quote styles, and formatting
+- **Easy Editing**: Make changes while keeping original formatting intact
+- **Modern API**: Built for Java 8+ with fluent builders, Stream-based navigation, and type-safe configuration
+- **Namespace Aware**: Comprehensive XML namespace support with resolution and context management
+- **XPath Queries**: Built-in mini-XPath for common queries, plus full XPath 1.0 via the Jaxen module
+- **Structural Diff**: XML-aware diff that distinguishes semantic changes from formatting-only changes
+- **SAX Interop**: Emit SAX events from DomTrip documents for JAXP pipeline integration
+- **JPMS Ready**: Ships with `module-info.java` descriptors
+- **Well Tested**: 1900+ tests covering XML conformance, round-trip fidelity, and edge cases
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Installation
 
@@ -25,7 +29,27 @@ Add DomTrip to your Maven project:
 ```xml
 <dependency>
     <groupId>eu.maveniverse.maven.domtrip</groupId>
+    <artifactId>domtrip-core</artifactId>
+    <version>1.2.0</version>
+</dependency>
+```
+
+For Maven POM editing (includes core):
+
+```xml
+<dependency>
+    <groupId>eu.maveniverse.maven.domtrip</groupId>
     <artifactId>domtrip-maven</artifactId>
+    <version>1.2.0</version>
+</dependency>
+```
+
+For full XPath 1.0 support (includes core):
+
+```xml
+<dependency>
+    <groupId>eu.maveniverse.maven.domtrip</groupId>
+    <artifactId>domtrip-jaxen</artifactId>
     <version>1.2.0</version>
 </dependency>
 ```
@@ -50,7 +74,15 @@ editor.addElement(newDep, "artifactId", "junit");
 String result = editor.toXml();
 ```
 
-## ✨ Key Features
+## Modules
+
+| Module | Artifact | Description |
+|--------|----------|-------------|
+| **core** | `domtrip-core` | Parser, serializer, editor, diff, visitor, XPath mini-language, SAX output |
+| **maven** | `domtrip-maven` | Maven POM-specific editing utilities |
+| **jaxen** | `domtrip-jaxen` | Full XPath 1.0 support via the Jaxen engine |
+
+## Key Features
 
 ### Lossless Preservation
 - **Comments**: Multi-line comments, inline comments, document comments
@@ -66,15 +98,87 @@ String result = editor.toXml();
 - **Type Safety**: Compile-time prevention of invalid operations
 - **Configuration**: Preset configurations for different use cases
 
+### XPath Queries
+
+Built-in mini-XPath handles the most common query patterns without any extra dependencies:
+
+```java
+// Path navigation with predicates
+root.xpath("dependencies/dependency[@scope='test']");
+root.xpath("//version");
+root.xpath("dependency[groupId='junit']/version");
+```
+
+For full XPath 1.0 support, add the `domtrip-jaxen` module:
+
+```java
+DomTripXPath xpath = new DomTripXPath("//dependency[starts-with(groupId, 'org.')]");
+List<?> results = xpath.selectNodes(root);
+```
+
+### Visitor / Walker
+
+Structured depth-first tree traversal with enter/exit callbacks:
+
+```java
+// Visitor interface
+element.accept(new DomTripVisitor() {
+    @Override
+    public Action enterElement(Element e) {
+        System.out.println("Entering: " + e.name());
+        return Action.CONTINUE;
+    }
+});
+
+// Lambda-friendly TreeWalker
+element.walk()
+    .onEnter(e -> {
+        System.out.println(e.name());
+        return DomTripVisitor.Action.CONTINUE;
+    })
+    .execute();
+```
+
+### XML Structural Diff
+
+Compare documents with XML-aware diff that distinguishes semantic changes from formatting-only changes:
+
+```java
+Document before = Document.of(oldXml);
+Document after = Document.of(newXml);
+
+DiffResult diff = XmlDiff.diff(before, after);
+
+for (XmlChange change : diff.changes()) {
+    System.out.println(change);
+}
+// ELEMENT_ADDED: /project/dependencies/dependency[3]
+// TEXT_CHANGED: /project/version: "1.0" -> "1.1"
+```
+
+### SAX Event Output
+
+Bridge DomTrip documents into SAX-based pipelines and JAXP APIs:
+
+```java
+// Emit SAX events
+SAXOutputter outputter = new SAXOutputter();
+outputter.output(doc, contentHandler);
+
+// Use as a JAXP SAXSource (e.g. with Transformer or Validator)
+SAXSource source = DomTripSAXSource.of(doc);
+transformer.transform(source, result);
+```
+
 ### Namespace Support
 - **Namespace-Aware Navigation**: Find elements by namespace URI and local name
 - **Context Management**: Automatic namespace resolution and prefix handling
 - **Builder Integration**: Create namespaced elements with fluent builders
 - **Preservation**: Maintains namespace declarations and prefixes
 
-## 📚 Documentation
+## Documentation
 
-**📖 [Complete Documentation](https://maveniverse.github.io/domtrip/)**
+**[Complete Documentation](https://maveniverse.github.io/domtrip/)**
 
 - **[Getting Started](https://maveniverse.github.io/domtrip/docs/getting-started/installation)** - Installation and quick start guide
 - **[Core Features](https://maveniverse.github.io/domtrip/docs/features/lossless-parsing)** - Lossless parsing, formatting preservation, namespaces
@@ -82,96 +186,7 @@ String result = editor.toXml();
 - **[Examples](https://maveniverse.github.io/domtrip/docs/examples/basic-editing)** - Real-world usage examples
 - **[Library Comparison](https://maveniverse.github.io/domtrip/docs/comparison)** - How DomTrip compares to other XML libraries
 
-## 🧪 Quality Assurance
-
-- **📊 Test Coverage: 100% (59/59 tests passing)**
-- **🔍 XML Conformance**: Full XML 1.0 specification compliance
-- **⚡ Performance**: Optimized for both memory usage and processing speed
-- **🛡️ Type Safety**: Compile-time prevention of invalid XML operations
-- **📝 Documentation**: Comprehensive documentation with live examples
-
-## 🏗️ Advanced Features
-
-### Factory Methods
-
-Create XML elements with convenient factory methods:
-
-```java
-// Simple elements
-Element version = Element.text("version", "1.0.0");
-Element properties = Element.of("properties");
-Element br = Element.selfClosing("br");
-
-// Elements with attributes
-Map<String, String> attrs = Map.of("scope", "test", "optional", "true");
-Element dependency = Element.withAttributes("dependency", attrs);
-
-// Namespaced elements
-QName soapEnvelope = QName.of("http://schemas.xmlsoap.org/soap/envelope/", "Envelope", "soap");
-Element nsElement = Element.of(soapEnvelope);
-Element defaultNs = Element.of(QName.of("http://example.com/ns", "item"));
-
-// Documents
-Document doc = Document.of().root(Element.of("project"));
-Document withDecl = Document.withXmlDeclaration("1.0", "UTF-8");
-```
-
-### Fluent API
-
-Create complex XML structures with fluent APIs:
-
-```java
-Element dependency = Element.of("dependency")
-    .attribute("scope", "test");
-dependency.addNode(Element.text("groupId", "junit"));
-dependency.addNode(Element.text("artifactId", "junit"));
-dependency.addNode(Element.text("version", "4.13.2"));
-```
-
-### Stream-Based Navigation
-
-Navigate XML documents with Java Streams:
-
-```java
-// Find all test dependencies
-root.descendants()
-    .filter(e -> "dependency".equals(e.name()))
-    .filter(e -> "test".equals(e.attribute("scope")))
-    .forEach(dep -> System.out.println(dep.child("artifactId").map(Element::textContent).orElse("")));
-```
-
-### Namespace-Aware Operations
-
-Work with XML namespaces naturally:
-
-```java
-// Find elements by namespace URI and local name
-QName soapBodyQName = QName.of("http://schemas.xmlsoap.org/soap/envelope/", "Body");
-Optional<Element> soapBody = root.child(soapBodyQName);
-
-// Create namespaced elements
-Element element = Element.of("item")
-    .namespaceDeclaration("ex", "http://example.com/ns")
-    .namespaceDeclaration(null, "http://example.com/default");
-```
-
-### Configuration Management
-
-Customize DomTrip behavior for different use cases:
-
-```java
-// Strict preservation (default)
-DomTripConfig strict = DomTripConfig.defaults();
-
-// Pretty printing for clean output
-DomTripConfig pretty = DomTripConfig.prettyPrint()
-    .withIndentString("  ")
-    .withDefaultQuoteStyle(QuoteStyle.DOUBLE);
-
-Editor editor = new Editor(Document.of(xml), pretty);
-```
-
-## 🏛️ Architecture
+## Architecture
 
 DomTrip uses a clean, type-safe architecture that enforces XML structure rules:
 
@@ -192,38 +207,44 @@ Node (abstract base)
 - **`Parser`** - XML parsing engine that captures all formatting metadata
 - **`Serializer`** - Minimal-change XML output generation
 - **`DomTripConfig`** - Configuration management with presets
+- **`XPathExpression`** - Mini-XPath query engine for element lookup
+- **`XmlDiff`** - XML-aware structural diff engine
+- **`DomTripVisitor` / `TreeWalker`** - Depth-first tree traversal
+- **`SAXOutputter`** - SAX event emission for JAXP interop
 
 ### Design Principles
-1. **🔒 Preservation First** - Original formatting preserved unless explicitly modified
-2. **📊 Metadata Tracking** - Each node tracks modification state and formatting
-3. **⚡ Minimal Changes** - Only modified sections are reformatted
-4. **🛡️ Type Safety** - Compile-time prevention of invalid operations
+1. **Preservation First** - Original formatting preserved unless explicitly modified
+2. **Metadata Tracking** - Each node tracks modification state and formatting
+3. **Minimal Changes** - Only modified sections are reformatted
+4. **Type Safety** - Compile-time prevention of invalid operations
 
-## 💡 Use Cases
+## Use Cases
 
 DomTrip excels in scenarios where preserving original formatting is crucial:
 
-- **📄 Configuration Files** - Update Maven POMs, Spring configs, web.xml while preserving comments and formatting
-- **🔄 Document Transformation** - Transform XML documents while maintaining original structure and style
-- **🛠️ XML Editing Tools** - Build XML editors and IDEs that respect user formatting preferences
-- **📝 Template Processing** - Process XML templates while preserving formatting for human readability
-- **🔧 Build Tools** - Modify build files programmatically without disrupting team formatting standards
+- **Configuration Files** - Update Maven POMs, Spring configs, web.xml while preserving comments and formatting
+- **Document Transformation** - Transform XML documents while maintaining original structure and style
+- **XML Editing Tools** - Build XML editors and IDEs that respect user formatting preferences
+- **Template Processing** - Process XML templates while preserving formatting for human readability
+- **Build Tools** - Modify build files programmatically without disrupting team formatting standards
 
-## 🎯 Comparison with Other Libraries
+## Comparison with Other Libraries
 
 | Feature | DomTrip | DOM4J | JDOM | Jackson XML |
 |---------|---------|-------|------|-------------|
-| **Lossless Round-Trip** | ✅ Perfect | ❌ No | ❌ No | ❌ No |
-| **Comment Preservation** | ✅ Yes | ✅ Yes | ✅ Yes | ❌ No |
-| **Between-Element Whitespace** | ✅ Exact | ⚠️ Partial | ✅ Yes* | ❌ No |
-| **In-Element Whitespace** | ✅ Exact | ❌ No | ⚠️ Configurable | ❌ No |
-| **Quote Style Preservation** | ✅ Yes | ❌ No | ❌ No | ❌ No |
-| **Attribute Order Preservation** | ✅ Yes | ❌ No | ❌ No | ❌ No |
-| **Entity Preservation** | ✅ Yes | ❌ No | ❌ No | ❌ No |
-| **Modern Java API** | ✅ Java 8+ | ❌ Legacy | ❌ Legacy | ✅ Modern |
-| **Stream Navigation** | ✅ Yes | ❌ No | ❌ No | ❌ No |
-| **Type Safety** | ✅ Compile-time | ❌ Runtime | ❌ Runtime | ✅ Compile-time |
-| **Performance** | ✅ Optimized | ✅ Fast | ✅ Fast | ✅ Very Fast |
+| **Lossless Round-Trip** | Yes | No | No | No |
+| **Comment Preservation** | Yes | Yes | Yes | No |
+| **Between-Element Whitespace** | Exact | Partial | Yes* | No |
+| **In-Element Whitespace** | Exact | No | Configurable | No |
+| **Quote Style Preservation** | Yes | No | No | No |
+| **Attribute Order Preservation** | Yes | No | No | No |
+| **Entity Preservation** | Yes | No | No | No |
+| **Modern Java API** | Java 8+ | Legacy | Legacy | Modern |
+| **Stream Navigation** | Yes | No | No | No |
+| **XPath** | Built-in + Jaxen | Jaxen | Built-in | No |
+| **Structural Diff** | Built-in | No | No | No |
+| **SAX Output** | Yes | Yes | Yes | No |
+| **Type Safety** | Compile-time | Runtime | Runtime | Compile-time |
 
 **\* JDOM Notes**:
 - `Format.getRawFormat()` preserves original whitespace between elements
@@ -231,33 +252,14 @@ DomTrip excels in scenarios where preserving original formatting is crucial:
 - Text content whitespace configurable via `TextMode.PRESERVE/TRIM/NORMALIZE`
 
 **Choose DomTrip when**: You need perfect formatting preservation for config files, documentation, or human-edited XML
+
 **Choose others when**: You only need data extraction, transformation, or high-throughput processing
 
-## 🧪 Development
+## Development
 
 ### Running Tests
 ```bash
 mvn test
-```
-
-### Interactive Demos
-Explore DomTrip features with interactive demos:
-
-```bash
-# Core editing features
-mvn test-compile exec:java -Dexec.mainClass="eu.maveniverse.domtrip.demos.EditorDemo" -Dexec.classpathScope=test
-
-# Builder patterns
-mvn test-compile exec:java -Dexec.mainClass="eu.maveniverse.domtrip.demos.BuilderPatternsDemo" -Dexec.classpathScope=test
-
-# Navigation features
-mvn test-compile exec:java -Dexec.mainClass="eu.maveniverse.domtrip.demos.NavigationDemo" -Dexec.classpathScope=test
-
-# Configuration options
-mvn test-compile exec:java -Dexec.mainClass="eu.maveniverse.domtrip.demos.ConfigurationDemo" -Dexec.classpathScope=test
-
-# Namespace handling
-mvn test-compile exec:java -Dexec.mainClass="eu.maveniverse.domtrip.demos.NamespaceDemo" -Dexec.classpathScope=test
 ```
 
 ### Building Documentation
@@ -268,59 +270,21 @@ npm start  # Development server
 npm run build  # Production build
 ```
 
-## 📋 Example: Before and After
-
-**Original XML:**
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Sample Maven POM -->
-<project xmlns="http://maven.apache.org/POM/4.0.0">
-    <groupId>com.example</groupId>
-    <artifactId>my-app</artifactId>
-    <version>1.0.0</version>
-</project>
-```
-
-**After editing with DomTrip:**
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Sample Maven POM -->
-<project xmlns="http://maven.apache.org/POM/4.0.0">
-    <groupId>com.example</groupId>
-    <artifactId>my-app</artifactId>
-    <version>2.0.0</version>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-</project>
-```
-
-**Notice how:**
-- ✅ Original formatting preserved (XML declaration, comments, indentation)
-- ✅ Only modified elements (`version`) and new elements (`dependencies`) changed
-- ✅ New elements follow inferred indentation patterns
-- ✅ Comments and namespace declarations maintained
-
-## 🤝 Contributing
+## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
-## 📄 License
+## License
 
 DomTrip is licensed under the [Eclipse Public License 2.0](LICENSE).
 
-## 🔗 Links
+## Links
 
-- **📖 [Documentation](https://maveniverse.github.io/domtrip/)**
-- **📦 [Maven Central](https://central.sonatype.com/artifact/eu.maveniverse.maven.domtrip/domtrip)**
-- **🐛 [Issues](https://github.com/maveniverse/domtrip/issues)**
-- **💬 [Discussions](https://github.com/maveniverse/domtrip/discussions)**
+- **[Documentation](https://maveniverse.github.io/domtrip/)**
+- **[Maven Central](https://central.sonatype.com/artifact/eu.maveniverse.maven.domtrip/domtrip-core)**
+- **[Issues](https://github.com/maveniverse/domtrip/issues)**
+- **[Discussions](https://github.com/maveniverse/domtrip/discussions)**
 
 ---
 
-**DomTrip** - *Perfect XML round-trips, every time* 🔄
+**DomTrip** - *Perfect XML round-trips, every time*


### PR DESCRIPTION
## Summary
- Add documentation for new features: XPath queries (mini-XPath + Jaxen), visitor/walker pattern, XML structural diff, SAX event output, JPMS support
- Add modules table showing core, maven, and jaxen artifacts
- Add XPath, Structural Diff, and SAX Output rows to comparison table
- Remove outdated test count (59/59), stale demo commands, and emojis
- Show `domtrip-core` as the primary installation artifact

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Shifted Maven artifact guidance to use domtrip-core (includes example for version 1.2.0) and added domtrip-jaxen for XPath 1.0.
  * Replaced emoji-style headings with plain headings and added a new "Modules" section.
  * Expanded docs for XPath queries, traversal (visitor/walker), XML structural diff, and SAX output.
  * Updated comparison table to Yes/No format and added rows for XPath, Structural Diff, and SAX Output.
  * Removed Interactive Demos and Before/After examples; adjusted footer tagline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->