### PR TITLE
ci: sync release drafter version with nisse build version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -DforceStdout -B -N 2>/dev/null | grep -v "^\[" | grep -v "^$")
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -DforceStdout -B -q -N)
           RELEASE_VERSION=${VERSION%-SNAPSHOT}
           echo "Nisse version: $VERSION -> Release version: $RELEASE_VERSION"
           gh api repos/${{ github.repository }}/releases/${{ steps.drafter.outputs.id }} \

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release drafter
+        id: drafter
         uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        if: github.event_name == 'push'
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        if: github.event_name == 'push'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Sync draft release version with build
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -DforceStdout -B -N 2>/dev/null | grep -v "^\[" | grep -v "^$")
+          RELEASE_VERSION=${VERSION%-SNAPSHOT}
+          echo "Nisse version: $VERSION -> Release version: $RELEASE_VERSION"
+          gh api repos/${{ github.repository }}/releases/${{ steps.drafter.outputs.id }} \
+            -X PATCH \
+            -f name="$RELEASE_VERSION" \
+            -f tag_name="$RELEASE_VERSION"


### PR DESCRIPTION
## Summary
- Add steps to the release-drafter workflow to read the project version from nisse (via Maven) and update the draft release name/tag accordingly
- This keeps the draft release version in sync with the `X.Y.Z-SNAPSHOT` git tags instead of relying on release-drafter's `$NEXT_PATCH_VERSION` computation

## Test plan
- [ ] Verify workflow runs on push to main and updates draft release version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow automation to auto-compute release versions (stripping snapshot suffix) and update draft release name and tag on push events.
  * Version-sync runs on direct pushes only; pull request events are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->