### PR TITLE
Fix #216: align comment and PI indentation with sibling elements in pretty print

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Serializer.java
@@ -720,7 +720,7 @@ public class Serializer {
         boolean hasElementChildren = element.children.stream().anyMatch(Element.class::isInstance);
 
         for (Node child : element.children) {
-            if (hasElementChildren && child instanceof Element) {
+            if (hasElementChildren && !(child instanceof Text)) {
                 serializeNodePretty(child, sb, depth + 1);
             } else {
                 serializeNode(child, sb);

--- a/core/src/test/java/eu/maveniverse/domtrip/SerializerExtendedTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/SerializerExtendedTest.java
@@ -532,4 +532,63 @@ class SerializerExtendedTest {
         byte[] out = baos.toByteArray();
         assertTrue(new String(out, StandardCharsets.UTF_8).contains("caf\u00e9"));
     }
+
+    @Test
+    void testPrettyPrintCommentAlignedWithSiblingElement() {
+        String xml = """
+                <project>
+                    <properties>
+                        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+                        <lombok.version>1.18.44</lombok.version>
+                    </properties>
+                </project>
+                """;
+        Document doc = Document.of(xml);
+        Serializer s = new Serializer(DomTripConfig.prettyPrint());
+        String result = s.serialize(doc);
+
+        assertTrue(result.contains("    <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->"));
+        assertTrue(result.contains("    <lombok.version>1.18.44</lombok.version>"));
+
+        String[] lines = result.split("\n");
+        String commentLine = null;
+        String elementLine = null;
+        for (String line : lines) {
+            if (line.contains("<!--")) commentLine = line;
+            if (line.contains("lombok.version")) elementLine = line;
+        }
+        assertNotNull(commentLine);
+        assertNotNull(elementLine);
+        int commentIndent = commentLine.indexOf("<!--");
+        int elementIndent = elementLine.indexOf("<lombok");
+        assertEquals(elementIndent, commentIndent, "Comment and element should have the same indentation");
+    }
+
+    @Test
+    void testPrettyPrintProcessingInstructionAlignedWithSiblingElement() {
+        String xml = """
+                <root>
+                    <parent>
+                        <?target data?>
+                        <child>value</child>
+                    </parent>
+                </root>
+                """;
+        Document doc = Document.of(xml);
+        Serializer s = new Serializer(DomTripConfig.prettyPrint());
+        String result = s.serialize(doc);
+
+        String[] lines = result.split("\n");
+        String piLine = null;
+        String elementLine = null;
+        for (String line : lines) {
+            if (line.contains("<?target")) piLine = line;
+            if (line.contains("<child>")) elementLine = line;
+        }
+        assertNotNull(piLine);
+        assertNotNull(elementLine);
+        int piIndent = piLine.indexOf("<?target");
+        int elementIndent = elementLine.indexOf("<child>");
+        assertEquals(elementIndent, piIndent, "Processing instruction and element should have the same indentation");
+    }
 }


### PR DESCRIPTION
## Summary

- Fix comment and processing instruction indentation in pretty print mode to align with sibling elements
- Previously, only `Element` nodes were routed through `serializeNodePretty` in `serializeChildrenPretty`, while `Comment` and `ProcessingInstruction` nodes preserved their original whitespace via `serializeNode`. This caused misaligned indentation when the original indent style differed from the pretty printer's configuration.
- The fix changes the condition from `child instanceof Element` to `!(child instanceof Text)`, so all non-text nodes (elements, comments, PIs) get consistent pretty-print indentation.

## Test plan

- [x] Added test for comment alignment with sibling elements
- [x] Added test for processing instruction alignment with sibling elements
- [x] All 1538 core tests pass
- [x] All 303 maven module tests pass

Fixes #216

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined mixed-content XML pretty-print serialization to improve handling of text nodes alongside other element types, ensuring more consistent output formatting.

* **Tests**
  * Added validation tests confirming comments and processing instructions maintain proper indentation alignment with sibling elements when serializing XML with pretty-print enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->