### PR TITLE
Fix #215: expose findManagedVersion as public API

### DIFF
--- a/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
+++ b/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
@@ -1658,7 +1658,7 @@ public class PomEditor extends AbstractMavenEditor {
          * @return the version text from the managed dependency, or {@code null} if not found
          * @since 1.2.0
          */
-        private String findManagedVersion(Coordinates coords) {
+        public String findManagedVersion(Coordinates coords) {
             Element depMgmt = findChildElement(root(), DEPENDENCY_MANAGEMENT);
             if (depMgmt == null) {
                 return null;

--- a/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
+++ b/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
@@ -2043,6 +2043,38 @@ class PomEditorTest {
     }
 
     @Test
+    void testFindManagedVersionFound() throws DomTripException {
+        PomEditor editor = editorOf(POM_WITH_MANAGED_DEPENDENCY);
+        Coordinates coords = Coordinates.of("org.springframework", "spring-core", "5.3.20");
+        String version = editor.dependencies().findManagedVersion(coords);
+        assertEquals("5.3.20", version);
+    }
+
+    @Test
+    void testFindManagedVersionNotFound() throws DomTripException {
+        PomEditor editor = editorOf(POM_WITH_MANAGED_DEPENDENCY);
+        Coordinates coords = Coordinates.of("org.example", "nonexistent", "1.0.0");
+        String version = editor.dependencies().findManagedVersion(coords);
+        assertNull(version);
+    }
+
+    @Test
+    void testFindManagedVersionNoDependencyManagement() throws DomTripException {
+        PomEditor editor = editorOf("<project></project>");
+        Coordinates coords = Coordinates.of("org.springframework", "spring-core", "5.3.20");
+        String version = editor.dependencies().findManagedVersion(coords);
+        assertNull(version);
+    }
+
+    @Test
+    void testFindManagedVersionEmptyDependencyManagement() throws DomTripException {
+        PomEditor editor = editorOf(POM_WITH_EMPTY_DEPENDENCY_MANAGEMENT);
+        Coordinates coords = Coordinates.of("org.springframework", "spring-core", "5.3.20");
+        String version = editor.dependencies().findManagedVersion(coords);
+        assertNull(version);
+    }
+
+    @Test
     void testUpdateManagedDependencyNoUpsert() throws DomTripException {
         String pom = "<project></project>";
         PomEditor editor = editorOf(pom);

--- a/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
+++ b/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
@@ -2045,7 +2045,7 @@ class PomEditorTest {
     @Test
     void testFindManagedVersionFound() throws DomTripException {
         PomEditor editor = editorOf(POM_WITH_MANAGED_DEPENDENCY);
-        Coordinates coords = Coordinates.of("org.springframework", "spring-core", "5.3.20");
+        Coordinates coords = Coordinates.of("org.springframework", "spring-core", null);
         String version = editor.dependencies().findManagedVersion(coords);
         assertEquals("5.3.20", version);
     }
@@ -2053,7 +2053,7 @@ class PomEditorTest {
     @Test
     void testFindManagedVersionNotFound() throws DomTripException {
         PomEditor editor = editorOf(POM_WITH_MANAGED_DEPENDENCY);
-        Coordinates coords = Coordinates.of("org.example", "nonexistent", "1.0.0");
+        Coordinates coords = Coordinates.of("org.example", "nonexistent", null);
         String version = editor.dependencies().findManagedVersion(coords);
         assertNull(version);
     }
@@ -2061,7 +2061,7 @@ class PomEditorTest {
     @Test
     void testFindManagedVersionNoDependencyManagement() throws DomTripException {
         PomEditor editor = editorOf("<project></project>");
-        Coordinates coords = Coordinates.of("org.springframework", "spring-core", "5.3.20");
+        Coordinates coords = Coordinates.of("org.springframework", "spring-core", null);
         String version = editor.dependencies().findManagedVersion(coords);
         assertNull(version);
     }
@@ -2069,9 +2069,31 @@ class PomEditorTest {
     @Test
     void testFindManagedVersionEmptyDependencyManagement() throws DomTripException {
         PomEditor editor = editorOf(POM_WITH_EMPTY_DEPENDENCY_MANAGEMENT);
-        Coordinates coords = Coordinates.of("org.springframework", "spring-core", "5.3.20");
+        Coordinates coords = Coordinates.of("org.springframework", "spring-core", null);
         String version = editor.dependencies().findManagedVersion(coords);
         assertNull(version);
+    }
+
+    @Test
+    void testFindManagedVersionPropertyReference() throws DomTripException {
+        String pom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-core</artifactId>
+                        <version>${spring.version}</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """;
+        PomEditor editor = editorOf(pom);
+        Coordinates coords = Coordinates.of("org.springframework", "spring-core", null);
+        String version = editor.dependencies().findManagedVersion(coords);
+        assertEquals("${spring.version}", version);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Make `PomEditor.Dependencies.findManagedVersion(Coordinates)` public so callers can check whether a dependency is already locally managed before performing mutations
- Add tests covering found, not-found, no dependency management, and empty dependency management cases

Closes #215

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed dependency version lookup is now publicly available in the API, enabling external access to version information.

* **Tests**
  * Added comprehensive test coverage for the version lookup feature, including tests for successful lookups, missing dependencies, and scenarios where dependency management sections are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->