### PR TITLE
Fix #214: add convention-aware updateManagedDependencyAligned API

### DIFF
--- a/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
+++ b/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
@@ -506,6 +506,113 @@ public class PomEditor extends AbstractMavenEditor {
             return updateOrCreateDependencyInContainer(dependencies, upsert, coordinates);
         }
 
+        /**
+         * Convention-aware version of {@link #updateManagedDependency(boolean, Coordinates)}.
+         *
+         * <p>Detects the project's version conventions and, when the convention calls for property-backed
+         * versions, creates (or updates) a version property and stores a {@code ${propName}} reference
+         * in the managed dependency element instead of the raw version string.</p>
+         *
+         * <p>This is equivalent to calling
+         * {@link #updateManagedDependencyAligned(boolean, Coordinates, AlignOptions)
+         * updateManagedDependencyAligned(upsert, coordinates, AlignOptions.defaults())}.</p>
+         *
+         * <h4>Example:</h4>
+         * <pre>{@code
+         * PomEditor editor = new PomEditor(document);
+         * Coordinates jackson = Coordinates.of("com.fasterxml.jackson.core", "jackson-databind", "2.15.0");
+         * // Auto-detects conventions; creates a property if the project uses property-backed versions
+         * editor.dependencies().updateManagedDependencyAligned(true, jackson);
+         * }</pre>
+         *
+         * @param upsert      whether to create the dependency if it doesn't exist
+         * @param coordinates the artifact coordinates (version is required)
+         * @return true if the dependency was updated or created, false otherwise
+         * @throws DomTripException if the coordinates are invalid or version is null
+         * @since 1.2.0
+         */
+        public boolean updateManagedDependencyAligned(boolean upsert, Coordinates coordinates) throws DomTripException {
+            return updateManagedDependencyAligned(upsert, coordinates, AlignOptions.defaults());
+        }
+
+        /**
+         * Convention-aware version of {@link #updateManagedDependency(boolean, Coordinates)} with
+         * explicit alignment options.
+         *
+         * <p>Resolves conventions (auto-detecting any fields left {@code null} in {@code options})
+         * and, when the effective version source is {@link AlignOptions.VersionSource#PROPERTY},
+         * creates or updates a version property and uses its {@code ${...}} reference as the
+         * version in the managed dependency element.</p>
+         *
+         * <h4>Example:</h4>
+         * <pre>{@code
+         * PomEditor editor = new PomEditor(document);
+         * Coordinates jackson = Coordinates.of("com.fasterxml.jackson.core", "jackson-databind", "2.15.0");
+         * editor.dependencies().updateManagedDependencyAligned(true, jackson,
+         *     AlignOptions.builder()
+         *         .versionSource(AlignOptions.VersionSource.PROPERTY)
+         *         .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+         *         .build());
+         * }</pre>
+         *
+         * @param upsert      whether to create the dependency if it doesn't exist
+         * @param coordinates the artifact coordinates (version is required)
+         * @param options     alignment options (null fields are auto-detected from the POM)
+         * @return true if the dependency was updated or created, false otherwise
+         * @throws DomTripException if the coordinates are invalid or version is null
+         * @since 1.2.0
+         */
+        public boolean updateManagedDependencyAligned(boolean upsert, Coordinates coordinates, AlignOptions options)
+                throws DomTripException {
+            requireGA(DEPENDENCY_LABEL, coordinates);
+            if (coordinates.version() == null) {
+                throw new DomTripException("Version is required for updateManagedDependencyAligned");
+            }
+
+            Object[] conventions = resolveConventions(options);
+            AlignOptions.VersionSource versionSource = (AlignOptions.VersionSource) conventions[1];
+            AlignOptions.PropertyNamingConvention naming = (AlignOptions.PropertyNamingConvention) conventions[2];
+
+            String actualVersion = coordinates.version();
+            String versionForElement = actualVersion;
+
+            if (versionSource == AlignOptions.VersionSource.PROPERTY) {
+                String propName = resolvePropertyName(coordinates, naming, options);
+                upsertVersionProperty(propName, actualVersion);
+                versionForElement = "${" + propName + "}";
+            }
+
+            Element dependencyManagement = findOrCreateElement(root(), DEPENDENCY_MANAGEMENT, upsert);
+            if (dependencyManagement == null) {
+                return false;
+            }
+            Element dependencies = findOrCreateElement(dependencyManagement, DEPENDENCIES, upsert);
+            if (dependencies == null) {
+                return false;
+            }
+
+            Element dependency = dependencies
+                    .childElements(DEPENDENCY)
+                    .filter(coordinates.predicateGATC())
+                    .findFirst()
+                    .orElse(null);
+
+            if (dependency == null && upsert) {
+                createNewDependency(dependencies, coordinates.withVersion(versionForElement));
+                return true;
+            }
+            if (dependency != null) {
+                java.util.Optional<Element> versionEl = dependency.childElement(VERSION);
+                if (versionEl.isPresent()) {
+                    versionEl.get().textContent(versionForElement);
+                } else {
+                    insertMavenElement(dependency, VERSION, versionForElement);
+                }
+                return true;
+            }
+            return false;
+        }
+
         private Element findOrCreateElement(Element parent, String childName, boolean create) throws DomTripException {
             Element child = findChildElement(parent, childName);
             if (child == null && create) {

--- a/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
+++ b/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
@@ -568,19 +568,13 @@ public class PomEditor extends AbstractMavenEditor {
             if (coordinates.version() == null) {
                 throw new DomTripException("Version is required for updateManagedDependencyAligned");
             }
+            if (options == null) {
+                options = AlignOptions.defaults();
+            }
 
             Object[] conventions = resolveConventions(options);
             AlignOptions.VersionSource versionSource = (AlignOptions.VersionSource) conventions[1];
             AlignOptions.PropertyNamingConvention naming = (AlignOptions.PropertyNamingConvention) conventions[2];
-
-            String actualVersion = coordinates.version();
-            String versionForElement = actualVersion;
-
-            if (versionSource == AlignOptions.VersionSource.PROPERTY) {
-                String propName = resolvePropertyName(coordinates, naming, options);
-                upsertVersionProperty(propName, actualVersion);
-                versionForElement = "${" + propName + "}";
-            }
 
             Element dependencyManagement = findOrCreateElement(root(), DEPENDENCY_MANAGEMENT, upsert);
             if (dependencyManagement == null) {
@@ -597,20 +591,30 @@ public class PomEditor extends AbstractMavenEditor {
                     .findFirst()
                     .orElse(null);
 
-            if (dependency == null && upsert) {
+            if (dependency == null && !upsert) {
+                return false;
+            }
+
+            String actualVersion = coordinates.version();
+            String versionForElement = actualVersion;
+
+            if (versionSource == AlignOptions.VersionSource.PROPERTY) {
+                String propName = resolvePropertyName(coordinates, naming, options);
+                upsertVersionProperty(propName, actualVersion);
+                versionForElement = "${" + propName + "}";
+            }
+
+            if (dependency == null) {
                 createNewDependency(dependencies, coordinates.withVersion(versionForElement));
                 return true;
             }
-            if (dependency != null) {
-                java.util.Optional<Element> versionEl = dependency.childElement(VERSION);
-                if (versionEl.isPresent()) {
-                    versionEl.get().textContent(versionForElement);
-                } else {
-                    insertMavenElement(dependency, VERSION, versionForElement);
-                }
-                return true;
+            java.util.Optional<Element> versionEl = dependency.childElement(VERSION);
+            if (versionEl.isPresent()) {
+                versionEl.get().textContent(versionForElement);
+            } else {
+                insertMavenElement(dependency, VERSION, versionForElement);
             }
-            return false;
+            return true;
         }
 
         private Element findOrCreateElement(Element parent, String childName, boolean create) throws DomTripException {

--- a/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
+++ b/maven/src/main/java/eu/maveniverse/domtrip/maven/PomEditor.java
@@ -529,7 +529,7 @@ public class PomEditor extends AbstractMavenEditor {
          * @param coordinates the artifact coordinates (version is required)
          * @return true if the dependency was updated or created, false otherwise
          * @throws DomTripException if the coordinates are invalid or version is null
-         * @since 1.2.0
+         * @since 1.4.0
          */
         public boolean updateManagedDependencyAligned(boolean upsert, Coordinates coordinates) throws DomTripException {
             return updateManagedDependencyAligned(upsert, coordinates, AlignOptions.defaults());
@@ -560,7 +560,7 @@ public class PomEditor extends AbstractMavenEditor {
          * @param options     alignment options (null fields are auto-detected from the POM)
          * @return true if the dependency was updated or created, false otherwise
          * @throws DomTripException if the coordinates are invalid or version is null
-         * @since 1.2.0
+         * @since 1.4.0
          */
         public boolean updateManagedDependencyAligned(boolean upsert, Coordinates coordinates, AlignOptions options)
                 throws DomTripException {
@@ -1369,7 +1369,7 @@ public class PomEditor extends AbstractMavenEditor {
          * @param parentEditor the parent POM editor where the managed dependency will be created
          * @param options alignment options controlling version source and property naming in the parent
          * @return {@code true} if the dependency was moved, {@code false} if not found or already version-less
-         * @since 1.2.0
+         * @since 1.4.0
          */
         public boolean alignToParent(Coordinates coords, PomEditor parentEditor, AlignOptions options) {
             requireGA(DEPENDENCY_LABEL, coords);
@@ -1414,7 +1414,7 @@ public class PomEditor extends AbstractMavenEditor {
          * @param parentEditor the parent POM editor where managed dependencies will be created
          * @param options alignment options controlling version source and property naming in the parent
          * @return the number of dependencies that were moved to the parent
-         * @since 1.2.0
+         * @since 1.4.0
          */
         public int alignAllToParent(PomEditor parentEditor, AlignOptions options) {
             Element deps = findChildElement(root(), DEPENDENCIES);
@@ -1526,7 +1526,7 @@ public class PomEditor extends AbstractMavenEditor {
          *
          * @param versionText the version text to resolve
          * @return the resolved literal version value
-         * @since 1.2.0
+         * @since 1.4.0
          */
         private String resolveVersionValue(String versionText) {
             if (!isPropertyReference(versionText)) {
@@ -1694,7 +1694,7 @@ public class PomEditor extends AbstractMavenEditor {
          * @param versionEl the {@code <version>} element to update
          * @param versionText the current text content of the version element
          * @return the resolved literal value if a change was made, or {@code null} if already literal or unresolvable
-         * @since 1.2.0
+         * @since 1.4.0
          */
         private String alignVersionToLiteral(Element versionEl, String versionText) {
             if (!isPropertyReference(versionText)) {
@@ -1767,7 +1767,7 @@ public class PomEditor extends AbstractMavenEditor {
          *
          * @param coords the dependency coordinates (matched by groupId/artifactId/type/classifier)
          * @return the version text from the managed dependency, or {@code null} if not found
-         * @since 1.2.0
+         * @since 1.4.0
          */
         public String findManagedVersion(Coordinates coords) {
             Element depMgmt = findChildElement(root(), DEPENDENCY_MANAGEMENT);

--- a/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
+++ b/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
@@ -2129,9 +2129,9 @@ class PomEditorTest {
     void testUpdateManagedDependencyAlignedWithoutVersionThrows() {
         PomEditor editor = editorOf(POM_INLINE_LITERAL);
         Coordinates noVersion = Coordinates.of("com.example", "lib", null);
+        PomEditor.Dependencies deps = editor.dependencies();
 
-        assertThrows(
-                DomTripException.class, () -> editor.dependencies().updateManagedDependencyAligned(true, noVersion));
+        assertThrows(DomTripException.class, () -> deps.updateManagedDependencyAligned(true, noVersion));
     }
 
     @Test

--- a/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
+++ b/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
@@ -2052,4 +2052,105 @@ class PomEditorTest {
         String xml = editor.toXml();
         assertFalse(xml.contains("<dependencyManagement>"), "No dependencyManagement should be created");
     }
+
+    @Test
+    void testUpdateManagedDependencyAlignedCreatesProperty() {
+        PomEditor editor = editorOf(POM_MANAGED_PROPERTY);
+        Coordinates jackson = Coordinates.of("com.fasterxml.jackson.core", "jackson-databind", "2.15.0");
+
+        boolean added = editor.dependencies().updateManagedDependencyAligned(true, jackson);
+        assertTrue(added);
+
+        String xml = editor.toXml();
+        assertTrue(xml.contains("<jackson-databind.version>2.15.0</jackson-databind.version>"));
+        assertTrue(xml.contains("${jackson-databind.version}"));
+    }
+
+    @Test
+    void testUpdateManagedDependencyAlignedLiteralConvention() {
+        PomEditor editor = editorOf(POM_INLINE_LITERAL);
+        Coordinates jackson = Coordinates.of("com.fasterxml.jackson.core", "jackson-databind", "2.15.0");
+
+        boolean added = editor.dependencies().updateManagedDependencyAligned(true, jackson);
+        assertTrue(added);
+
+        String xml = editor.toXml();
+        assertTrue(xml.contains("<version>2.15.0</version>"));
+        assertFalse(xml.contains("jackson-databind.version"));
+    }
+
+    @Test
+    void testUpdateManagedDependencyAlignedUpdatesExistingProperty() {
+        PomEditor editor = editorOf(POM_MANAGED_PROPERTY);
+        Coordinates guava = Coordinates.of("com.google.guava", "guava", "33.0.0-jre");
+
+        boolean updated = editor.dependencies().updateManagedDependencyAligned(false, guava);
+        assertTrue(updated);
+
+        String xml = editor.toXml();
+        assertTrue(xml.contains("<guava.version>33.0.0-jre</guava.version>"));
+        assertTrue(xml.contains("${guava.version}"));
+    }
+
+    @Test
+    void testUpdateManagedDependencyAlignedWithExplicitOptions() {
+        PomEditor editor = editorOf(POM_INLINE_LITERAL);
+        Coordinates jackson = Coordinates.of("com.fasterxml.jackson.core", "jackson-databind", "2.15.0");
+
+        boolean added = editor.dependencies()
+                .updateManagedDependencyAligned(
+                        true,
+                        jackson,
+                        AlignOptions.builder()
+                                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                                .build());
+        assertTrue(added);
+
+        String xml = editor.toXml();
+        assertTrue(xml.contains("<jackson-databind.version>2.15.0</jackson-databind.version>"));
+        assertTrue(xml.contains("${jackson-databind.version}"));
+    }
+
+    @Test
+    void testUpdateManagedDependencyAlignedNoUpsert() {
+        String pom = "<project></project>";
+        PomEditor editor = editorOf(pom);
+        Coordinates dep = Coordinates.of("com.example", "lib", "1.0.0");
+
+        boolean result = editor.dependencies().updateManagedDependencyAligned(false, dep);
+        assertFalse(result);
+
+        String xml = editor.toXml();
+        assertFalse(xml.contains("<dependencyManagement>"));
+    }
+
+    @Test
+    void testUpdateManagedDependencyAlignedWithoutVersionThrows() {
+        PomEditor editor = editorOf(POM_INLINE_LITERAL);
+        Coordinates noVersion = Coordinates.of("com.example", "lib", null);
+
+        assertThrows(
+                DomTripException.class, () -> editor.dependencies().updateManagedDependencyAligned(true, noVersion));
+    }
+
+    @Test
+    void testUpdateManagedDependencyAlignedWithPropertyNameGenerator() {
+        PomEditor editor = editorOf(POM_INLINE_LITERAL);
+        Coordinates jackson = Coordinates.of("com.fasterxml.jackson.core", "jackson-databind", "2.15.0");
+
+        boolean added = editor.dependencies()
+                .updateManagedDependencyAligned(
+                        true,
+                        jackson,
+                        AlignOptions.builder()
+                                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                                .propertyNameGenerator(coords -> coords.groupId() + ".version")
+                                .build());
+        assertTrue(added);
+
+        String xml = editor.toXml();
+        assertTrue(xml.contains("<com.fasterxml.jackson.core.version>2.15.0</com.fasterxml.jackson.core.version>"));
+        assertTrue(xml.contains("${com.fasterxml.jackson.core.version}"));
+    }
 }

--- a/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
+++ b/maven/src/test/java/eu/maveniverse/domtrip/maven/PomEditorTest.java
@@ -2126,6 +2126,19 @@ class PomEditorTest {
     }
 
     @Test
+    void testUpdateManagedDependencyAlignedNoUpsertPropertyConvention() {
+        PomEditor editor = editorOf(POM_MANAGED_PROPERTY);
+        Coordinates dep = Coordinates.of("com.example", "nonexistent-lib", "1.0.0");
+
+        boolean result = editor.dependencies().updateManagedDependencyAligned(false, dep);
+        assertFalse(result);
+
+        String xml = editor.toXml();
+        assertFalse(xml.contains("nonexistent-lib"), "No dependency element should be created");
+        assertFalse(xml.contains("nonexistent-lib.version"), "No property should be created");
+    }
+
+    @Test
     void testUpdateManagedDependencyAlignedWithoutVersionThrows() {
         PomEditor editor = editorOf(POM_INLINE_LITERAL);
         Coordinates noVersion = Coordinates.of("com.example", "lib", null);

--- a/maven/src/test/java/eu/maveniverse/domtrip/maven/snippets/PomEditorSnippetsTest.java
+++ b/maven/src/test/java/eu/maveniverse/domtrip/maven/snippets/PomEditorSnippetsTest.java
@@ -60,6 +60,7 @@ class PomEditorSnippetsTest {
         addAligned();
         alignExistingDependency();
         alignAllDependencies();
+        updateManagedDependencyAligned();
     }
 
     @Test
@@ -748,6 +749,74 @@ class PomEditorSnippetsTest {
         // END: align-all
 
         assertEquals(2, changed);
+    }
+
+    void updateManagedDependencyAligned() throws DomTripException {
+        // START: update-managed-aligned
+        String pom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>my-project</artifactId>
+                  <version>1.0.0</version>
+                  <properties>
+                    <slf4j.version>2.0.7</slf4j.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                        <version>${slf4j.version}</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+
+        PomEditor editor = new PomEditor(Document.of(pom));
+
+        // Add a new managed dependency following auto-detected conventions
+        // Detects PROPERTY + DOT_SUFFIX → creates property and uses ${...} reference
+        Coordinates jackson = Coordinates.of("com.fasterxml.jackson.core", "jackson-core", "2.15.2");
+        editor.dependencies().updateManagedDependencyAligned(true, jackson);
+
+        // Use explicit options to force property-backed version
+        Coordinates guava = Coordinates.of("com.google.guava", "guava", "33.0.0-jre");
+        editor.dependencies()
+                .updateManagedDependencyAligned(
+                        true,
+                        guava,
+                        AlignOptions.builder()
+                                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                                .build());
+
+        // Use explicit property name to update an existing managed dependency
+        Coordinates slf4j = Coordinates.of("org.slf4j", "slf4j-api", "2.0.13");
+        editor.dependencies()
+                .updateManagedDependencyAligned(
+                        false,
+                        slf4j,
+                        AlignOptions.builder().propertyName("slf4j.version").build());
+        // END: update-managed-aligned
+
+        String result = editor.toXml();
+        // New dependency got an auto-generated property
+        assertTrue(result.contains("<jackson-core.version>2.15.2</jackson-core.version>"));
+        assertTrue(result.contains("${jackson-core.version}"));
+        // Explicit options created property
+        assertTrue(result.contains("<guava.version>33.0.0-jre</guava.version>"));
+        assertTrue(result.contains("${guava.version}"));
+        // Explicit property name preserved existing convention
+        assertTrue(result.contains("<slf4j.version>2.0.13</slf4j.version>"));
     }
 
     // ========== PROFILE SNIPPETS (profiles.md) ==========

--- a/website/content/docs/maven/alignment.md
+++ b/website/content/docs/maven/alignment.md
@@ -59,6 +59,17 @@ Apply conventions consistently across all dependencies in a single call:
 {cdi:snippets.snippet('align-all')}
 ```
 
+## Updating Managed Dependencies (Aligned)
+
+Use `updateManagedDependencyAligned()` to add or update entries in `<dependencyManagement>`
+while following the project's detected conventions. Unlike `updateManagedDependency()` which
+always inlines the raw version string, this method creates version properties when the project
+convention calls for them:
+
+```java
+{cdi:snippets.snippet('update-managed-aligned')}
+```
+
 ## AlignOptions
 
 `AlignOptions` controls how alignment operations behave. Use the builder for explicit control,

--- a/website/content/docs/maven/alignment.md
+++ b/website/content/docs/maven/alignment.md
@@ -62,9 +62,9 @@ Apply conventions consistently across all dependencies in a single call:
 ## Updating Managed Dependencies (Aligned)
 
 Use `updateManagedDependencyAligned()` to add or update entries in `<dependencyManagement>`
-while following the project's detected conventions. Unlike `updateManagedDependency()` which
-always inlines the raw version string, this method creates version properties when the project
-convention calls for them:
+while following the project's detected conventions. Where `updateManagedDependency()` stores
+the version string you pass in directly, this method creates version properties when the
+project convention calls for them:
 
 ```java
 {cdi:snippets.snippet('update-managed-aligned')}

--- a/website/content/docs/maven/api.md
+++ b/website/content/docs/maven/api.md
@@ -102,6 +102,9 @@ Access via `editor.dependencies()`.
 {cdi:snippets.snippet('dependency-management-ops')}
 ```
 
+For convention-aware managed dependency updates (creating version properties automatically),
+see `updateManagedDependencyAligned()` in [Dependency Alignment](../alignment/).
+
 ### Exclusion Management
 
 See [Exclusion Management](../exclusions/) for full documentation.


### PR DESCRIPTION
## Summary

- Adds `updateManagedDependencyAligned(boolean upsert, Coordinates coordinates)` and `updateManagedDependencyAligned(boolean upsert, Coordinates coordinates, AlignOptions options)` to `PomEditor.Dependencies`
- Detects project conventions (property vs literal, naming convention) and creates/updates version properties when appropriate, rather than always inlining the raw version string
- Reuses existing internal helpers (`resolveConventions`, `resolvePropertyName`, `upsertVersionProperty`) to stay consistent with `addAligned`/`alignDependency`

Closes #214

## Test plan

- [x] New managed dependency in property-convention POM creates version property and uses `${propName}` reference
- [x] New managed dependency in literal-convention POM uses inline version without creating properties
- [x] Updating existing property-backed managed dependency updates the property value correctly
- [x] Explicit `AlignOptions` override auto-detected conventions
- [x] `upsert=false` returns false and makes no changes when dependency doesn't exist
- [x] Null version throws `DomTripException`
- [x] Custom `propertyNameGenerator` is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convention-aware methods for updating managed dependencies while automatically detecting and respecting project alignment patterns. Version properties are generated when applicable for improved configuration management.

* **Documentation**
  * Updated Maven API documentation with guidance on convention-aware dependency version management, including usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->