### PR TITLE
feat: add feature for detecting attribute ordering changes

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/ChangeType.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/ChangeType.java
@@ -42,6 +42,9 @@ public enum ChangeType {
     /** An attribute value was modified. */
     ATTRIBUTE_CHANGED,
 
+    /** An attribute was moved. */
+    ATTRIBUTE_MOVED,
+
     /** A comment was inserted. */
     COMMENT_ADDED,
 
@@ -87,6 +90,7 @@ public enum ChangeType {
             case QUOTE_STYLE_CHANGED:
             case ENTITY_FORM_CHANGED:
             case EMPTY_ELEMENT_STYLE_CHANGED:
+            case ATTRIBUTE_MOVED:
                 return false;
             default:
                 return true;

--- a/core/src/main/java/eu/maveniverse/domtrip/DiffResult.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DiffResult.java
@@ -170,7 +170,7 @@ public class DiffResult {
      * {@link ChangeType#ATTRIBUTE_MOVED} change.</p>
      *
      * @return {@code true} if there are attribute order changes
-     * @since 1.4.0
+     * @since 1.5.0
      */
     public boolean hasAttributeOrderChanges() {
         return changes.stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED);

--- a/core/src/main/java/eu/maveniverse/domtrip/DiffResult.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/DiffResult.java
@@ -158,6 +158,24 @@ public class DiffResult {
         return changes.stream().anyMatch(XmlChange::isFormattingOnly);
     }
 
+    /**
+     * Returns {@code true} if any changes affecting attribute order were detected.
+     *
+     * <p>Attribute order is not considered a semantic difference in XML, but in
+     * many real-world use cases (configuration files, generated build metadata
+     * etc.) it is desirable to detect reordering separately from other
+     * formatting-only changes like whitespace or quote styles.</p>
+     *
+     * <p>This method reports {@code true} when the diff contains an
+     * {@link ChangeType#ATTRIBUTE_MOVED} change.</p>
+     *
+     * @return {@code true} if there are attribute order changes
+     * @since 1.4.0
+     */
+    public boolean hasAttributeOrderChanges() {
+        return changes.stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED);
+    }
+
     @Override
     public String toString() {
         if (changes.isEmpty()) {

--- a/core/src/main/java/eu/maveniverse/domtrip/XmlDiff.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/XmlDiff.java
@@ -197,7 +197,7 @@ public final class XmlDiff {
             Element after,
             List<XmlChange> changes) {
         // We might have different length of lists and / or different attributes, to not double-detect these as order
-        // changers we first filter both
+        // changes we first filter both
         // for the same keys.
         Set<String> commonKeys = new LinkedHashSet<>(beforeAttrs.keySet());
         commonKeys.retainAll(afterAttrs.keySet());

--- a/core/src/main/java/eu/maveniverse/domtrip/XmlDiff.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/XmlDiff.java
@@ -183,6 +183,50 @@ public final class XmlDiff {
                         after));
             }
         }
+
+        // Attribute reordering: if the same set of attributes with the same values
+        // exists in both elements, detect changes in their relative order.
+        detectAttributeOrderChanges(beforeAttrs, afterAttrs, path, before, after, changes);
+    }
+
+    private static void detectAttributeOrderChanges(
+            Map<String, Attribute> beforeAttrs,
+            Map<String, Attribute> afterAttrs,
+            String path,
+            Element before,
+            Element after,
+            List<XmlChange> changes) {
+        // We might have different length of lists and / or different attributes, to not double-detect these as order
+        // changers we first filter both
+        // for the same keys.
+        Set<String> commonKeys = new LinkedHashSet<>(beforeAttrs.keySet());
+        commonKeys.retainAll(afterAttrs.keySet());
+
+        // Build ordered lists (keySet of LinkedHashMap is ordered) of common attributes
+        List<String> beforeCommonKeys =
+                beforeAttrs.keySet().stream().filter(commonKeys::contains).collect(Collectors.toList());
+        List<String> afterCommonKeys =
+                afterAttrs.keySet().stream().filter(commonKeys::contains).collect(Collectors.toList());
+
+        if (beforeCommonKeys.equals(afterCommonKeys)) {
+            return; // No reordering
+        }
+
+        // Emit ATTRIBUTE_MOVED for attributes whose position changed.
+        for (String name : beforeCommonKeys) {
+            int beforeIndex = beforeCommonKeys.indexOf(name);
+            int afterIndex = afterCommonKeys.indexOf(name);
+            if (beforeIndex != afterIndex) {
+                String attrPath = path + "/@" + name;
+                changes.add(new XmlChange(
+                        ChangeType.ATTRIBUTE_MOVED,
+                        attrPath,
+                        Integer.toString(beforeIndex),
+                        Integer.toString(afterIndex),
+                        before,
+                        after));
+            }
+        }
     }
 
     private static void compareAttributeValues(

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -584,6 +584,21 @@ class XmlDiffTest {
         assertTrue(result.hasChanges(), "Attribute missing should be detected");
     }
 
+    @Test
+    void detectsNoAttributeReorderingIfDifferent() {
+        Document before = Document.of("<root a=\"1\" b=\"2\" c=\"3\"/>");
+        Document after = Document.of("<root b=\"2\" c=\"3\" d=\"3\"/>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
+        assertFalse(
+                result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
+                "Expected no ATTRIBUTE_MOVED for reordered attributes");
+        assertFalse(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be false");
+        assertTrue(result.hasChanges(), "Attribute missing should be detected");
+    }
+
     // --- Assertion helpers ---
 
     private static void assertChange(DiffResult result, ChangeType expectedType, String expectedPath) {

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -554,6 +554,20 @@ class XmlDiffTest {
         assertFalse(nameChanges.stream().anyMatch(c -> c.path().startsWith("/project/namespace")));
     }
 
+    @Test
+    void detectsAttributeReorderingAsAttributeMoved() {
+        Document before = Document.of("<root a=\"1\" b=\"2\"/>");
+        Document after = Document.of("<root b=\"2\" a=\"1\"/>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
+        assertTrue(
+                result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
+                "Expected ATTRIBUTE_MOVED for reordered attributes");
+        assertFalse(result.hasSemanticChanges(), "Attribute reordering should not be semantic");
+    }
+
     // --- Assertion helpers ---
 
     private static void assertChange(DiffResult result, ChangeType expectedType, String expectedPath) {

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -7,7 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for XML-aware structural diff.
@@ -554,64 +558,78 @@ class XmlDiffTest {
         assertFalse(nameChanges.stream().anyMatch(c -> c.path().startsWith("/project/namespace")));
     }
 
-    @Test
-    void detectsAttributeReorderingAsAttributeMoved() {
-        Document before = Document.of("<root a=\"1\" b=\"2\"/>");
-        Document after = Document.of("<root b=\"2\" a=\"1\"/>");
+    private static Stream<Arguments> attributeReorderingCases() {
+        return Stream.of(
+                // Reordered attributes, no semantic change
+                Arguments.of("reordered attributes", "<root a=\"1\" b=\"2\"/>", "<root b=\"2\" a=\"1\"/>", false),
+                // Reordered attributes with namespaces, no semantic change
+                Arguments.of(
+                        "reordered attributes with namespaces",
+                        "<root xmlns1:a=\"1\" xmlns2:b=\"2\"/>",
+                        "<root xmlns2:b=\"2\" xmlns1:a=\"1\"/>",
+                        false),
+                // Attribute 'a' moved and its value changed from 1 to 3 -> ATTRIBUTE_MOVED + ATTRIBUTE_CHANGED
+                Arguments.of(
+                        "reordered and changed attribute", "<root a=\"1\" b=\"2\"/>", "<root b=\"2\" a=\"3\"/>", true));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("attributeReorderingCases")
+    void detectsAttributeReorderingAsAttributeMoved(
+            String description, String beforeXml, String afterXml, boolean expectSemanticChange) {
+        Document before = Document.of(beforeXml);
+        Document after = Document.of(afterXml);
 
         DiffResult result = XmlDiff.diff(before, after);
 
-        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
+        // Attribute reordering should always be reported as ATTRIBUTE_MOVED in these scenarios
         assertTrue(
                 result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
                 "Expected ATTRIBUTE_MOVED for reordered attributes");
         assertTrue(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be true");
-        assertFalse(result.hasSemanticChanges(), "Attribute reordering should not be semantic");
+
+        if (expectSemanticChange) {
+            assertTrue(result.hasSemanticChanges(), "Expected semantic changes for this scenario");
+        } else {
+            assertFalse(result.hasSemanticChanges(), "Attribute reordering alone should not be semantic");
+        }
     }
 
-    @Test
-    void detectsNoAttributeReorderingIfMissing() {
-        Document before = Document.of("<root a=\"1\" b=\"2\" c=\"3\"/>");
-        Document after = Document.of("<root b=\"2\" c=\"3\"/>");
+    private static Stream<Arguments> attributesNotReorderedCases() {
+        return Stream.of(
+                // 1) Attributes identical – no changes at all
+                Arguments.of(
+                        "same attributes", "<root a=\"1\" b=\"2\" c=\"3\"/>", "<root a=\"1\" b=\"2\" c=\"3\"/>", false),
+                // 2) One attribute missing
+                Arguments.of("missing attribute", "<root a=\"1\" b=\"2\" c=\"3\"/>", "<root b=\"2\" c=\"3\"/>", true),
+                // 3) Different attribute set
+                Arguments.of(
+                        "different attributes",
+                        "<root a=\"1\" b=\"2\" c=\"3\"/>",
+                        "<root b=\"2\" c=\"3\" d=\"3\"/>",
+                        true));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("attributesNotReorderedCases")
+    void detectsNoAttributeReordering(
+            String description, String beforeXml, String afterXml, boolean expectedHasChanges) {
+        Document before = Document.of(beforeXml);
+        Document after = Document.of(afterXml);
 
         DiffResult result = XmlDiff.diff(before, after);
 
-        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
+        // Attribute reordering should not be reported in these scenarios
         assertFalse(
                 result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
-                "Expected no ATTRIBUTE_MOVED for reordered attributes");
+                "Expected no ATTRIBUTE_MOVED for these attribute differences");
         assertFalse(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be false");
-        assertTrue(result.hasChanges(), "Attribute missing should be detected");
-    }
 
-    @Test
-    void detectsNoAttributeReorderingIfDifferent() {
-        Document before = Document.of("<root a=\"1\" b=\"2\" c=\"3\"/>");
-        Document after = Document.of("<root b=\"2\" c=\"3\" d=\"3\"/>");
-
-        DiffResult result = XmlDiff.diff(before, after);
-
-        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
-        assertFalse(
-                result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
-                "Expected no ATTRIBUTE_MOVED for reordered attributes");
-        assertFalse(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be false");
-        assertTrue(result.hasChanges(), "Attribute missing should be detected");
-    }
-
-    @Test
-    void detectsAttributeReorderingAsAttributeMovedWithNamespaces() {
-        Document before = Document.of("<root xmlns1:a=\"1\" xmlns2:b=\"2\"/>");
-        Document after = Document.of("<root xmlns2:b=\"2\" xmlns1:a=\"1\"/>");
-
-        DiffResult result = XmlDiff.diff(before, after);
-
-        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
-        assertTrue(
-                result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
-                "Expected ATTRIBUTE_MOVED for reordered attributes with namespaces");
-        assertTrue(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be true");
-        assertFalse(result.hasSemanticChanges(), "Attribute reordering should not be semantic");
+        if (expectedHasChanges) {
+            assertTrue(result.hasChanges(), "Attribute difference should be detected");
+        } else {
+            assertFalse(result.hasChanges(), "No changes should be detected when attributes are identical");
+        }
     }
 
     // --- Assertion helpers ---

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -565,6 +565,7 @@ class XmlDiffTest {
         assertTrue(
                 result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
                 "Expected ATTRIBUTE_MOVED for reordered attributes");
+        assertTrue(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be true");
         assertFalse(result.hasSemanticChanges(), "Attribute reordering should not be semantic");
     }
 

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -569,6 +569,21 @@ class XmlDiffTest {
         assertFalse(result.hasSemanticChanges(), "Attribute reordering should not be semantic");
     }
 
+    @Test
+    void detectsNoAttributeReorderingIfMissing() {
+        Document before = Document.of("<root a=\"1\" b=\"2\" c=\"3\"/>");
+        Document after = Document.of("<root b=\"2\" c=\"3\"/>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
+        assertFalse(
+                result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
+                "Expected no ATTRIBUTE_MOVED for reordered attributes");
+        assertFalse(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be false");
+        assertTrue(result.hasChanges(), "Attribute missing should be detected");
+    }
+
     // --- Assertion helpers ---
 
     private static void assertChange(DiffResult result, ChangeType expectedType, String expectedPath) {

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -565,8 +565,8 @@ class XmlDiffTest {
                 // Reordered attributes with namespaces, no semantic change
                 Arguments.of(
                         "reordered attributes with namespaces",
-                        "<root xmlns1:a=\"1\" xmlns2:b=\"2\"/>",
-                        "<root xmlns2:b=\"2\" xmlns1:a=\"1\"/>",
+                        "<root xmlns:n1=\"urn:one\" xmlns:n2=\"urn:two\" n1:a=\"1\" n2:b=\"2\"/>",
+                        "<root xmlns:n1=\"urn:one\" xmlns:n2=\"urn:two\" n2:b=\"2\" n1:a=\"1\"/>",
                         false),
                 // Attribute 'a' moved and its value changed from 1 to 3 -> ATTRIBUTE_MOVED + ATTRIBUTE_CHANGED
                 Arguments.of(

--- a/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/XmlDiffTest.java
@@ -599,6 +599,21 @@ class XmlDiffTest {
         assertTrue(result.hasChanges(), "Attribute missing should be detected");
     }
 
+    @Test
+    void detectsAttributeReorderingAsAttributeMovedWithNamespaces() {
+        Document before = Document.of("<root xmlns1:a=\"1\" xmlns2:b=\"2\"/>");
+        Document after = Document.of("<root xmlns2:b=\"2\" xmlns1:a=\"1\"/>");
+
+        DiffResult result = XmlDiff.diff(before, after);
+
+        // Attribute reordering should be formatting-only and reported as ATTRIBUTE_MOVED
+        assertTrue(
+                result.changes().stream().anyMatch(c -> c.type() == ChangeType.ATTRIBUTE_MOVED),
+                "Expected ATTRIBUTE_MOVED for reordered attributes with namespaces");
+        assertTrue(result.hasAttributeOrderChanges(), "Expected hasAttributeOrderChanges() to be true");
+        assertFalse(result.hasSemanticChanges(), "Attribute reordering should not be semantic");
+    }
+
     // --- Assertion helpers ---
 
     private static void assertChange(DiffResult result, ChangeType expectedType, String expectedPath) {


### PR DESCRIPTION
Closes #225 

This would be my proposal for detecting moved attributes.

I added a unit test for it, that makes sure we don't misdetect it as a semantic change now.

Also I wasn't sure if you want to have `ATTRIBUTE_MOVED` as a formatting change or not. Right now !isSemantic -> it's a formatting change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * XML attribute reordering is now detected and reported as a formatting-only (non-semantic) change.
  * Added a public query to check whether a diff contains attribute order changes.

* **Tests**
  * Added tests verifying detection of attribute reordering and that such changes are non-semantic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/domtrip/pull/226)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->