### PR TITLE
Make addBlankLineBefore/After idempotent

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/Editor.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Editor.java
@@ -2117,7 +2117,16 @@ public class Editor {
     }
 
     private boolean hasBlankLine(String whitespace) {
-        return whitespace != null && whitespace.contains(lineEnding + lineEnding);
+        if (whitespace == null || lineEnding.isEmpty()) {
+            return false;
+        }
+        String[] lines = whitespace.split(lineEnding, -1);
+        for (int i = 1; i < lines.length - 1; i++) {
+            if (lines[i].trim().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/core/src/main/java/eu/maveniverse/domtrip/Editor.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Editor.java
@@ -2091,21 +2091,33 @@ public class Editor {
     }
 
     public void addBlankLineBefore(Element element) {
-        element.precedingWhitespace(lineEnding + element.precedingWhitespace());
+        String ws = element.precedingWhitespace();
+        if (!hasBlankLine(ws)) {
+            element.precedingWhitespace(lineEnding + ws);
+        }
     }
 
     public void addBlankLineAfter(Element element) {
-        // Add an extra newline to create a blank line
         if (element.parent() instanceof Element) {
             Element parentElement = (Element) element.parent();
             int index = parentElement.children.indexOf(element);
             if (index == parentElement.children.size() - 1) {
-                parentElement.innerPrecedingWhitespace(lineEnding + parentElement.innerPrecedingWhitespace());
+                String ws = parentElement.innerPrecedingWhitespace();
+                if (!hasBlankLine(ws)) {
+                    parentElement.innerPrecedingWhitespace(lineEnding + ws);
+                }
             } else {
                 Node nextSibling = parentElement.children.get(index + 1);
-                nextSibling.precedingWhitespace(lineEnding + nextSibling.precedingWhitespace());
+                String ws = nextSibling.precedingWhitespace();
+                if (!hasBlankLine(ws)) {
+                    nextSibling.precedingWhitespace(lineEnding + ws);
+                }
             }
         }
+    }
+
+    private boolean hasBlankLine(String whitespace) {
+        return whitespace != null && whitespace.contains(lineEnding + lineEnding);
     }
 
     /**

--- a/core/src/test/java/eu/maveniverse/domtrip/EditorInsertRemoveTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/EditorInsertRemoveTest.java
@@ -311,6 +311,19 @@ class EditorInsertRemoveTest {
     }
 
     @Test
+    void testAddBlankLineBeforeNoOpForRawFormatting() throws DomTripException {
+        String xml = "<root><existing>content</existing><other>value</other></root>";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element other = doc.root().childElement("other").orElseThrow();
+
+        editor.addBlankLineBefore(other);
+
+        assertEquals(xml, editor.toXml());
+    }
+
+    @Test
     void testRemoveElementNullHandling() throws DomTripException {
         // Test null element
         assertFalse(editor.removeElement(null));

--- a/core/src/test/java/eu/maveniverse/domtrip/EditorInsertRemoveTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/EditorInsertRemoveTest.java
@@ -245,6 +245,44 @@ class EditorInsertRemoveTest {
     }
 
     @Test
+    void testAddBlankLineBeforeIsIdempotent() throws DomTripException {
+        String xml = """
+            <root>
+                <existing>content</existing>
+
+                <other>value</other>
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element other = doc.root().childElement("other").orElseThrow();
+
+        editor.addBlankLineBefore(other);
+        String result = editor.toXml();
+
+        assertEquals(xml, result);
+    }
+
+    @Test
+    void testAddBlankLineAfterIsIdempotent() throws DomTripException {
+        String xml = """
+            <root>
+                <existing>content</existing>
+
+                <other>value</other>
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element existing = doc.root().childElement("existing").orElseThrow();
+
+        editor.addBlankLineAfter(existing);
+        String result = editor.toXml();
+
+        assertEquals(xml, result);
+    }
+
+    @Test
     void testRemoveElementNullHandling() throws DomTripException {
         // Test null element
         assertFalse(editor.removeElement(null));

--- a/core/src/test/java/eu/maveniverse/domtrip/EditorInsertRemoveTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/EditorInsertRemoveTest.java
@@ -283,6 +283,34 @@ class EditorInsertRemoveTest {
     }
 
     @Test
+    void testAddBlankLineBeforeIsIdempotentWithWhitespaceOnlyBlankLine() throws DomTripException {
+        String xml = "<root>\n    <existing>content</existing>\n    \n    <other>value</other>\n</root>";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element other = doc.root().childElement("other").orElseThrow();
+
+        editor.addBlankLineBefore(other);
+        String result = editor.toXml();
+
+        assertEquals(xml, result);
+    }
+
+    @Test
+    void testAddBlankLineAfterIsIdempotentWithWhitespaceOnlyBlankLine() throws DomTripException {
+        String xml = "<root>\n    <existing>content</existing>\n    \n    <other>value</other>\n</root>";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element existing = doc.root().childElement("existing").orElseThrow();
+
+        editor.addBlankLineAfter(existing);
+        String result = editor.toXml();
+
+        assertEquals(xml, result);
+    }
+
+    @Test
     void testRemoveElementNullHandling() throws DomTripException {
         // Test null element
         assertFalse(editor.removeElement(null));


### PR DESCRIPTION
## Summary

- `addBlankLineBefore()` and `addBlankLineAfter()` now check whether a blank line already exists before adding one, preventing double blank lines
- Adds `hasBlankLine()` helper that checks for consecutive `lineEnding` sequences in whitespace

## Context

When `PomEditor.insertElementAtPosition()` inserts an element with blank line markers in the ordering config (e.g., `<pluginManagement>` into `<build>`), it calls `addBlankLineAfter()`. If the next sibling (`<plugins>`) already has its normal `\n`-prefixed whitespace, the unconditional `lineEnding` prepend creates a double blank line. Tools like Spotless then flag this as a formatting violation.

This was discovered during Maven 4 compatibility testing: `mvnup apply` adds `<pluginManagement>` entries to POM files, and Sling projects using `spotless-maven-plugin` would fail because the modified POM had double blank lines between `</pluginManagement>` and `<plugins>`.

## Test plan

- [x] New `testAddBlankLineBeforeIsIdempotent` — verifies calling `addBlankLineBefore` on an element that already has a blank line before it is a no-op
- [x] New `testAddBlankLineAfterIsIdempotent` — verifies calling `addBlankLineAfter` on an element that already has a blank line after it is a no-op
- [x] All existing blank line tests still pass (adding blank lines where none exist)
- [x] Full test suite: 316 tests pass, 0 failures

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced blank-line insertion logic to be idempotent and prevent duplicate blank lines. The system now intelligently inspects existing whitespace patterns before adding new lines, ensuring predictable formatting behavior when operations are repeated on the same content.

* **Tests**
  * Added test cases to verify idempotent behavior of blank-line insertion helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/domtrip/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->