### PR TITLE
Add COMBINE_REMOVE constant to MavenPomElements.Attributes

### DIFF
--- a/maven/src/main/java/eu/maveniverse/domtrip/maven/MavenPomElements.java
+++ b/maven/src/main/java/eu/maveniverse/domtrip/maven/MavenPomElements.java
@@ -155,6 +155,7 @@ public final class MavenPomElements {
         public static final String COMBINE_OVERRIDE = "override";
         public static final String COMBINE_MERGE = "merge";
         public static final String COMBINE_APPEND = "append";
+        public static final String COMBINE_REMOVE = "remove";
 
         private Attributes() {
             // Utility class

--- a/maven/src/main/java/eu/maveniverse/domtrip/maven/MavenPomElements.java
+++ b/maven/src/main/java/eu/maveniverse/domtrip/maven/MavenPomElements.java
@@ -155,7 +155,6 @@ public final class MavenPomElements {
         public static final String COMBINE_OVERRIDE = "override";
         public static final String COMBINE_MERGE = "merge";
         public static final String COMBINE_APPEND = "append";
-        public static final String COMBINE_REMOVE = "remove";
 
         private Attributes() {
             // Utility class


### PR DESCRIPTION
## Summary
- Add missing `COMBINE_REMOVE = "remove"` constant to `MavenPomElements.Attributes`
- This completes the set of `combine.self` attribute values: `override`, `merge`, `remove`
- Needed by maven PR [apache/maven#12160](https://github.com/apache/maven/pull/12160) which currently hardcodes `"remove"`

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new attribute option to Maven project object model (POM) processing, expanding configuration flexibility for Maven-based project management and build workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/domtrip/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->