### PR TITLE
Fix #254: Add Editor.insertCommentBefore/After methods

### DIFF
--- a/core/src/main/java/eu/maveniverse/domtrip/Editor.java
+++ b/core/src/main/java/eu/maveniverse/domtrip/Editor.java
@@ -604,6 +604,117 @@ public class Editor {
         return comment;
     }
 
+    /**
+     * Inserts a comment before the specified reference element.
+     *
+     * <p>This method creates a new comment and inserts it immediately before
+     * the reference element in the parent's child list. The comment's whitespace
+     * is automatically inferred from the reference element's context, matching
+     * the behavior of {@link #insertElementBefore(Element, String)}.</p>
+     *
+     * <h3>Example:</h3>
+     * <pre>{@code
+     * // Before:
+     * // <plugins>
+     * //     <plugin>...</plugin>
+     * // </plugins>
+     *
+     * editor.insertCommentBefore(pluginElement, " Override version inherited from parent ");
+     *
+     * // After:
+     * // <plugins>
+     * //     <!-- Override version inherited from parent -->
+     * //     <plugin>...</plugin>
+     * // </plugins>
+     * }</pre>
+     *
+     * @param referenceElement the element to insert the comment before
+     * @param text the comment text (without the {@code <!-- -->} delimiters)
+     * @return the newly created comment
+     * @throws DomTripException if the reference element is null, has no parent, or is not found in its parent
+     * @see #insertCommentAfter(Element, String)
+     * @see #addComment(ContainerNode, String)
+     */
+    public Comment insertCommentBefore(Element referenceElement, String text) throws DomTripException {
+        return insertCommentRelativeTo(referenceElement, text, 0);
+    }
+
+    /**
+     * Inserts a comment after the specified reference element.
+     *
+     * <p>This method creates a new comment and inserts it immediately after
+     * the reference element in the parent's child list. The comment's whitespace
+     * is automatically inferred from the reference element's context, matching
+     * the behavior of {@link #insertElementAfter(Element, String)}.</p>
+     *
+     * <h3>Example:</h3>
+     * <pre>{@code
+     * // Before:
+     * // <plugins>
+     * //     <plugin>...</plugin>
+     * //     <plugin>...</plugin>
+     * // </plugins>
+     *
+     * editor.insertCommentAfter(firstPlugin, " Next plugin section ");
+     *
+     * // After:
+     * // <plugins>
+     * //     <plugin>...</plugin>
+     * //     <!-- Next plugin section -->
+     * //     <plugin>...</plugin>
+     * // </plugins>
+     * }</pre>
+     *
+     * @param referenceElement the element to insert the comment after
+     * @param text the comment text (without the {@code <!-- -->} delimiters)
+     * @return the newly created comment
+     * @throws DomTripException if the reference element is null, has no parent, or is not found in its parent
+     * @see #insertCommentBefore(Element, String)
+     * @see #addComment(ContainerNode, String)
+     */
+    public Comment insertCommentAfter(Element referenceElement, String text) throws DomTripException {
+        return insertCommentRelativeTo(referenceElement, text, 1);
+    }
+
+    /**
+     * Shared implementation for {@link #insertCommentBefore} and {@link #insertCommentAfter}.
+     * Validates inputs, creates the comment with inferred whitespace, and inserts it at the
+     * reference element's index plus the given offset.
+     *
+     * @param referenceElement the element to position relative to
+     * @param text the comment text
+     * @param indexOffset 0 to insert before the reference element, 1 to insert after
+     * @return the newly created comment
+     */
+    private Comment insertCommentRelativeTo(Element referenceElement, String text, int indexOffset)
+            throws DomTripException {
+        if (referenceElement == null) {
+            throw new DomTripException("Reference element cannot be null");
+        }
+
+        ContainerNode parent = referenceElement.parent();
+        if (parent == null) {
+            throw new DomTripException("Reference element has no parent");
+        }
+
+        int index = parent.children.indexOf(referenceElement);
+        if (index < 0) {
+            throw new DomTripException("Reference element not found in parent");
+        }
+
+        Comment comment = new Comment(text != null ? text : "");
+
+        // Normalize whitespace and adjust index (same as element insertion)
+        index = normalizeWhitespaces(parent, index);
+
+        // Infer proper indentation from the parent context
+        String properIndentation = inferIndentation(parent);
+        comment.precedingWhitespace(lineEnding + properIndentation);
+
+        parent.insertChild(index + indexOffset, comment);
+        return comment;
+    }
+
     // ========== ELEMENT COMMENTING METHODS ==========
 
     /**
@@ -881,29 +992,7 @@ public class Editor {
      * @throws DomTripException if the insertion fails
      */
     public Element insertElementBefore(Element referenceElement, String elementName) throws DomTripException {
-        if (referenceElement == null) {
-            throw new DomTripException("Reference element cannot be null");
-        }
-        if (elementName == null || elementName.trim().isEmpty()) {
-            throw new DomTripException("Element name cannot be null or empty");
-        }
-
-        ContainerNode parent = referenceElement.parent();
-        if (parent == null) {
-            throw new DomTripException("Reference element has no parent");
-        }
-
-        int index = parent.children.indexOf(referenceElement);
-        if (index < 0) {
-            throw new DomTripException("Reference element not found in parent");
-        }
-
-        Element newElement = new Element(elementName.trim());
-
-        // Use centralized node insertion with automatic whitespace normalization
-        insertChild(parent, newElement, index);
-
-        return newElement;
+        return insertElementRelativeTo(referenceElement, elementName, 0);
     }
 
     /**
@@ -943,6 +1032,21 @@ public class Editor {
      * @throws DomTripException if the insertion fails
      */
     public Element insertElementAfter(Element referenceElement, String elementName) throws DomTripException {
+        return insertElementRelativeTo(referenceElement, elementName, 1);
+    }
+
+    /**
+     * Shared implementation for {@link #insertElementBefore} and {@link #insertElementAfter}.
+     * Validates inputs, creates the element, and inserts it at the reference element's index
+     * plus the given offset.
+     *
+     * @param referenceElement the element to position relative to
+     * @param elementName the name of the new element
+     * @param indexOffset 0 to insert before the reference element, 1 to insert after
+     * @return the newly created element
+     */
+    private Element insertElementRelativeTo(Element referenceElement, String elementName, int indexOffset)
+            throws DomTripException {
         if (referenceElement == null) {
             throw new DomTripException("Reference element cannot be null");
         }
@@ -963,7 +1067,7 @@ public class Editor {
         Element newElement = new Element(elementName.trim());
 
         // Use centralized node insertion with automatic whitespace normalization
-        insertChild(parent, newElement, index + 1);
+        insertChild(parent, newElement, index + indexOffset);
 
         return newElement;
     }

--- a/core/src/test/java/eu/maveniverse/domtrip/EditorCommentingTest.java
+++ b/core/src/test/java/eu/maveniverse/domtrip/EditorCommentingTest.java
@@ -220,6 +220,271 @@ class EditorCommentingTest {
         assertEquals(xml, result);
     }
 
+    // ========== insertCommentBefore / insertCommentAfter tests ==========
+
+    @Test
+    void testInsertCommentBeforeElement() throws DomTripException {
+        String xml = """
+            <root>
+                <first>content1</first>
+                <second>content2</second>
+            </root>""";
+        String expected = """
+            <root>
+                <first>content1</first>
+                <!-- inserted comment -->
+                <second>content2</second>
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element second = doc.root().childElement("second").orElseThrow();
+
+        Comment comment = editor.insertCommentBefore(second, " inserted comment ");
+
+        assertNotNull(comment);
+        assertEquals(" inserted comment ", comment.content());
+        assertEquals(doc.root(), comment.parent());
+
+        String result = editor.toXml();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testInsertCommentAfterElement() throws DomTripException {
+        String xml = """
+            <root>
+                <first>content1</first>
+                <second>content2</second>
+            </root>""";
+        String expected = """
+            <root>
+                <first>content1</first>
+                <!-- inserted comment -->
+                <second>content2</second>
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element first = doc.root().childElement("first").orElseThrow();
+
+        Comment comment = editor.insertCommentAfter(first, " inserted comment ");
+
+        assertNotNull(comment);
+        assertEquals(" inserted comment ", comment.content());
+        assertEquals(doc.root(), comment.parent());
+
+        String result = editor.toXml();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testInsertCommentBeforeFirstElement() throws DomTripException {
+        String xml = """
+            <root>
+                <first>content1</first>
+                <second>content2</second>
+            </root>""";
+        String expected = """
+            <root>
+                <!-- before first -->
+                <first>content1</first>
+                <second>content2</second>
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element first = doc.root().childElement("first").orElseThrow();
+
+        editor.insertCommentBefore(first, " before first ");
+
+        String result = editor.toXml();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testInsertCommentAfterLastElement() throws DomTripException {
+        String xml = """
+            <root>
+                <first>content1</first>
+                <second>content2</second>
+            </root>""";
+        String expected = """
+            <root>
+                <first>content1</first>
+                <second>content2</second>
+                <!-- after last -->
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element second = doc.root().childElement("second").orElseThrow();
+
+        editor.insertCommentAfter(second, " after last ");
+
+        String result = editor.toXml();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testInsertCommentBeforeWithDeepNesting() throws DomTripException {
+        String xml = """
+            <root>
+                <dependencies>
+                    <dependency>
+                        <groupId>junit</groupId>
+                    </dependency>
+                </dependencies>
+            </root>""";
+        String expected = """
+            <root>
+                <dependencies>
+                    <!-- Override version inherited from parent -->
+                    <dependency>
+                        <groupId>junit</groupId>
+                    </dependency>
+                </dependencies>
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element dependency = doc.root()
+                .childElement("dependencies")
+                .orElseThrow()
+                .childElement("dependency")
+                .orElseThrow();
+
+        editor.insertCommentBefore(dependency, " Override version inherited from parent ");
+
+        String result = editor.toXml();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testInsertCommentBeforeNullElement() {
+        assertThrows(DomTripException.class, () -> editor.insertCommentBefore(null, "text"));
+    }
+
+    @Test
+    void testInsertCommentAfterNullElement() {
+        assertThrows(DomTripException.class, () -> editor.insertCommentAfter(null, "text"));
+    }
+
+    @Test
+    void testInsertCommentBeforeOrphanElement() {
+        Element orphan = new Element("orphan");
+        assertThrows(DomTripException.class, () -> editor.insertCommentBefore(orphan, "text"));
+    }
+
+    @Test
+    void testInsertCommentAfterOrphanElement() {
+        Element orphan = new Element("orphan");
+        assertThrows(DomTripException.class, () -> editor.insertCommentAfter(orphan, "text"));
+    }
+
+    @Test
+    void testInsertCommentWithNullText() throws DomTripException {
+        String xml = """
+            <root>
+                <child>content</child>
+            </root>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element child = doc.root().childElement("child").orElseThrow();
+
+        Comment comment = editor.insertCommentBefore(child, null);
+
+        assertNotNull(comment);
+        assertEquals("", comment.content());
+    }
+
+    @Test
+    void testInsertCommentBeforeInMavenPluginScenario() throws DomTripException {
+        String xml = """
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>""";
+        String expected = """
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                    <!-- Override version inherited from parent -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element plugins = doc.root().childElement("plugins").orElseThrow();
+        Element secondPlugin = plugins.childElements()
+                .filter(e -> "plugin".equals(e.name()))
+                .skip(1)
+                .findFirst()
+                .orElseThrow();
+
+        editor.insertCommentBefore(secondPlugin, " Override version inherited from parent ");
+
+        String result = editor.toXml();
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testInsertCommentAfterInMavenPluginScenario() throws DomTripException {
+        String xml = """
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>""";
+        String expected = """
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                    <!-- Next section -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>""";
+
+        Document doc = Document.of(xml);
+        editor = new Editor(doc);
+        Element plugins = doc.root().childElement("plugins").orElseThrow();
+        Element firstPlugin = plugins.childElement("plugin").orElseThrow();
+
+        editor.insertCommentAfter(firstPlugin, " Next section ");
+
+        String result = editor.toXml();
+        assertEquals(expected, result);
+    }
+
     @Test
     void testUncommentElementWithPrettyPrint() throws DomTripException {
         String xml = """


### PR DESCRIPTION
## Summary

- Add `insertCommentBefore(Element, String)` and `insertCommentAfter(Element, String)` methods to `Editor` that mirror the whitespace inference logic of `insertElementBefore/After`
- New methods automatically set `precedingWhitespace` on the created `Comment` node, ensuring comments are placed on their own line with proper indentation
- Add 12 test cases covering: basic before/after insertion, first/last element edge cases, deep nesting, null/orphan error handling, null text, and Maven POM-like scenarios

## Motivation

`Editor.addComment()` correctly infers indentation but only appends. There was no positional variant for inserting comments before or after a specific element. This forced callers to use the raw `ContainerNode.insertChildBefore` API which doesn't set `precedingWhitespace`, causing comments to appear on the same line as the preceding element's closing tag:

```xml
<!-- What callers got -->
            </plugin><!-- Override version inherited from parent -->
            <plugin>

<!-- What callers wanted -->
            </plugin>
            <!-- Override version inherited from parent -->
            <plugin>
```

This was hit in Apache Maven's `mvnup` tool (`PluginUpgradeStrategy`), which had to work around the missing API by manually setting `precedingWhitespace` (see [apache/maven#12443](https://github.com/apache/maven/pull/12443)).

## Test plan

- [x] All 12 new tests in `EditorCommentingTest` pass
- [x] Full core test suite passes (1569 tests, 0 failures)
- [x] Full reactor build passes (excluding pre-existing website module dependency issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inserting comments before or after a selected element in editor content.
  * Comment placement now preserves surrounding formatting and indentation automatically.

* **Tests**
  * Added coverage for comment insertion at sibling boundaries, nested elements, and document edges.
  * Added validation checks for invalid references and empty comment text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->