### PR TITLE
chore(deps): bump version.quarkus-roq from 2.1.4 to 2.1.5

### DIFF
--- a/website/pom.xml
+++ b/website/pom.xml
@@ -24,7 +24,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <version.quarkus.platform>3.36.3</version.quarkus.platform>
-    <version.quarkus-roq>2.1.4</version.quarkus-roq>
+    <version.quarkus-roq>2.1.5</version.quarkus-roq>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Summary

- Bump `version.quarkus-roq` from 2.1.4 to 2.1.5 in `website/pom.xml` to fix CI build failure
- The `quarkus-roq-theme-default-deployment:2.1.4` artifact's transitive dependency chain fails to resolve in the Quarkus bootstrap resolver, breaking all CI builds including PRs like #255
- Version 2.1.5 resolves this with updated dependencies (notably `fontawesome-free` 7.2.0 → 7.3.0)
- Supersedes dependabot PR #253

## Test plan

- [x] Full reactor build passes locally (`mvn verify` — all 5 modules SUCCESS)
- [x] Website module tests pass (8 tests, 0 failures)
- [ ] CI build passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)