### PR TITLE
ci: fix SonarCloud plugin resolution after cache invalidation

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,15 +32,18 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        PR_KEY: ${{ github.event.pull_request.number }}
+        PR_BRANCH: ${{ github.head_ref }}
+        PR_BASE: ${{ github.base_ref }}
       run: >-
         ./mvnw --no-transfer-progress
-        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
+        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report org.sonarsource.scanner.maven:sonar-maven-plugin:5.7.0.6970:sonar
         -Dsonar.projectKey=maveniverse_domtrip
         -Dsonar.organization=maveniverse
         -Dsonar.host.url=https://sonarcloud.io
-        -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-        -Dsonar.pullrequest.branch=${{ github.head_ref }}
-        -Dsonar.pullrequest.base=${{ github.base_ref }}
+        -Dsonar.pullrequest.key="$PR_KEY"
+        -Dsonar.pullrequest.branch="$PR_BRANCH"
+        -Dsonar.pullrequest.base="$PR_BASE"
         -Dsonar.coverage.exclusions=website/src/main/java/**
 
     - name: Build and analyze (push)


### PR DESCRIPTION
## Summary

- Replace `sonar:sonar` shorthand with fully qualified `org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` in the SonarCloud workflow

## Root Cause

The SonarCloud workflow has been failing since the Parent POM 62 update (#266) with:

```
[ERROR] No plugin found for prefix 'sonar' in the current project and in the plugin groups
[com.diffplug.spotless, org.gaul, org.eclipse.sisu, com.mycila, eu.maveniverse.maven.plugins,
org.apache.maven.plugins, org.codehaus.mojo]
```

The `sonar` prefix is registered in the `org.sonarsource.scanner.maven` group metadata on Maven Central — **not** in any of the plugin groups configured in the parent POM. The shorthand `sonar:sonar` previously worked only because the CI Maven cache contained a stale prefix mapping from `org.codehaus.mojo:sonar-maven-plugin` (a relocation POM). When the parent POM bump to v62 changed the cache key, the cache was invalidated, and Maven could no longer resolve the prefix.

This was always a latent issue — any cache invalidation would have triggered it.

## Test plan

- [ ] SonarCloud workflow passes on this PR (the "Build and analyze (PR)" step)
- [ ] After merge, the "Build and analyze (push)" step passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and consistency of automated code quality analysis for pull requests and code updates.
  * Standardized analysis reporting across supported code changes.
  * No changes were made to application functionality or the end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->