### PR TITLE
chore: support reproducible builds from source archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.mvn/nisse.properties export-subst

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,4 @@
 -Dnisse.source.jgit.dynamicVersion=true
+-Dnisse.source.jgit.dateFormat=iso8601
 # to support "nested invocation" done by website (to build javadoc)
 -Dnisse.inliner.suppressCleanup=true

--- a/.mvn/nisse.properties
+++ b/.mvn/nisse.properties
@@ -1,0 +1,3 @@
+# Fallback values for source archives (expanded by git archive via export-subst)
+nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
+nisse.jgit.date=$Format:%cI$

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.testRelease>21</maven.compiler.testRelease>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>${nisse.jgit.date}</project.build.outputTimestamp>
     <version.junit>6.1.3</version.junit>
   </properties>
 


### PR DESCRIPTION
## Summary

Add nisse fallback properties and git export-subst support so that builds from source archives (e.g. GitHub's "Download Source" tarballs or `git archive`) can resolve the project version and commit date without a `.git` directory.

Inspired by [jline3@b46e19a](https://github.com/jline/jline3/commit/b46e19a050259319be92f1aafad6f47eb6a647a2) and [jline3#2152](https://github.com/jline/jline3/pull/2152).

### Changes

- **`.mvn/nisse.properties`** — fallback values expanded by `git archive` via `export-subst`:
  - `nisse.jgit.dynamicVersion` from `%(describe:tags=true)`
  - `nisse.jgit.date` from `%cI` (committer date, matching what nisse computes from JGit)
- **`.gitattributes`** — enables `export-subst` on `nisse.properties`
- **`.mvn/maven.config`** — sets `nisse.source.jgit.dateFormat=iso8601` so the date property is valid for `project.build.outputTimestamp`
- **`pom.xml`** — overrides `project.build.outputTimestamp` with `${nisse.jgit.date}` so the reproducible-build timestamp reflects the actual commit date instead of the parent POM's static release timestamp

### Why

Without this, building from a source archive fails because nisse can't resolve `${nisse.jgit.dynamicVersion}` (no `.git` dir). Additionally, `project.build.outputTimestamp` was inherited from the parent POM as a static value (`2026-08-10T20:16:30Z`) unrelated to any domtrip commit.

## Test plan

- [x] `mvn clean verify -B` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved release metadata handling by incorporating Git version and date information into generated builds.
  * Added fallback values to ensure build metadata remains available when Git archive details are unavailable.
  * Standardized build timestamps using ISO 8601 formatting, supporting more consistent and reproducible build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->